### PR TITLE
Implement initialization parameters per workspace, profile, flow

### DIFF
--- a/crate/cfg/Cargo.toml
+++ b/crate/cfg/Cargo.toml
@@ -16,9 +16,9 @@ doctest = false
 test = false
 
 [dependencies]
-async-trait = "0.1.56"
-nougat = "0.2.1"
+async-trait = "0.1.57"
+nougat = "0.2.4"
 peace_core = { path = "../core", version = "0.0.2" }
 peace_data = { path = "../data", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
-serde = { version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }

--- a/crate/core/Cargo.toml
+++ b/crate/core/Cargo.toml
@@ -17,4 +17,4 @@ test = false
 
 [dependencies]
 peace_static_check_macros = { path = "../static_check_macros", version = "0.0.2" }
-serde = { version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }

--- a/crate/data/Cargo.toml
+++ b/crate/data/Cargo.toml
@@ -16,5 +16,5 @@ doctest = false
 test = false
 
 [dependencies]
-fn_graph = { version = "0.5.2", features = ["resman"] }
+fn_graph = { version = "0.5.4", features = ["resman"] }
 peace_data_derive = { path = "../data_derive", version = "0.0.2" }

--- a/crate/data_derive/Cargo.toml
+++ b/crate/data_derive/Cargo.toml
@@ -17,6 +17,6 @@ doctest = false
 test = false
 
 [dependencies]
-syn = "1.0.98"
-quote = "1.0.20"
-proc-macro2 = "1.0.40"
+syn = "1.0.100"
+quote = "1.0.21"
+proc-macro2 = "1.0.44"

--- a/crate/diff/Cargo.toml
+++ b/crate/diff/Cargo.toml
@@ -16,4 +16,4 @@ doctest = false
 test = false
 
 [dependencies]
-serde = { version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }

--- a/crate/resources/Cargo.toml
+++ b/crate/resources/Cargo.toml
@@ -19,6 +19,6 @@ test = false
 peace_core = { version = "0.0.2", path = "../core" }
 peace_data = { version = "0.0.2", path = "../data" }
 resman = { version = "0.15.0", features = ["debug"] }
-serde = { version = "1.0.139", features = ["derive"] }
-tokio = { version = "1.20.0", features = ["sync"] }
+serde = { version = "1.0.145", features = ["derive"] }
+tokio = { version = "1.21.1", features = ["sync"] }
 type_reg = { version = "0.3.1", features = ["debug", "untagged", "ordered"] }

--- a/crate/resources/src/internal.rs
+++ b/crate/resources/src/internal.rs
@@ -6,7 +6,7 @@
 pub use self::{
     flow_init_file::FlowInitFile, op_check_statuses::OpCheckStatuses,
     profile_init_file::ProfileInitFile, state_diffs_mut::StateDiffsMut, states_mut::StatesMut,
-    workspace_dirs::WorkspaceDirs,
+    workspace_dirs::WorkspaceDirs, workspace_init_file::WorkspaceInitFile,
 };
 
 mod flow_init_file;
@@ -15,3 +15,4 @@ mod profile_init_file;
 mod state_diffs_mut;
 mod states_mut;
 mod workspace_dirs;
+mod workspace_init_file;

--- a/crate/resources/src/internal.rs
+++ b/crate/resources/src/internal.rs
@@ -4,11 +4,14 @@
 //! framework). There may be breakage between releases.
 
 pub use self::{
-    op_check_statuses::OpCheckStatuses, state_diffs_mut::StateDiffsMut, states_mut::StatesMut,
+    flow_init_file::FlowInitFile, op_check_statuses::OpCheckStatuses,
+    profile_init_file::ProfileInitFile, state_diffs_mut::StateDiffsMut, states_mut::StatesMut,
     workspace_dirs::WorkspaceDirs,
 };
 
+mod flow_init_file;
 mod op_check_statuses;
+mod profile_init_file;
 mod state_diffs_mut;
 mod states_mut;
 mod workspace_dirs;

--- a/crate/resources/src/internal/flow_init_file.rs
+++ b/crate/resources/src/internal/flow_init_file.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use crate::paths::FlowDir;
+
+/// Path to the file that stores the flow initialization parameters.
+///
+/// Typically `$workspace_dir/.peace/$profile/$flow_id/init.yaml`.
+///
+/// See `FlowInitFile::from<&FlowDir>` if you want to construct a
+/// `FlowInitFile` with the conventional `$flow_dir/init.yaml`
+/// path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlowInitFile(PathBuf);
+
+crate::paths::pathbuf_newtype!(FlowInitFile);
+
+impl FlowInitFile {
+    /// File name of the initialization parameters file.
+    pub const NAME: &'static str = "init.yaml";
+}
+
+impl From<&FlowDir> for FlowInitFile {
+    fn from(flow_dir: &FlowDir) -> Self {
+        let path = flow_dir.join(Self::NAME);
+
+        Self(path)
+    }
+}

--- a/crate/resources/src/internal/profile_init_file.rs
+++ b/crate/resources/src/internal/profile_init_file.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use crate::paths::ProfileDir;
+
+/// Path to the file that stores the profile initialization parameters.
+///
+/// Typically `$workspace_dir/.peace/$profile/init.yaml`.
+///
+/// See `ProfileInitFile::from<&ProfileDir>` if you want to construct a
+/// `ProfileInitFile` with the conventional `$profile_dir/init.yaml`
+/// path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProfileInitFile(PathBuf);
+
+crate::paths::pathbuf_newtype!(ProfileInitFile);
+
+impl ProfileInitFile {
+    /// File name of the initialization parameters file.
+    pub const NAME: &'static str = "init.yaml";
+}
+
+impl From<&ProfileDir> for ProfileInitFile {
+    fn from(flow_dir: &ProfileDir) -> Self {
+        let path = flow_dir.join(Self::NAME);
+
+        Self(path)
+    }
+}

--- a/crate/resources/src/internal/workspace_init_file.rs
+++ b/crate/resources/src/internal/workspace_init_file.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use crate::paths::PeaceDir;
+
+/// Path to the file that stores the workspace initialization parameters.
+///
+/// Typically `$workspace_dir/.peace/init.yaml`.
+///
+/// See `WorkspaceInitFile::from<&PeaceDir>` if you want to construct a
+/// `WorkspaceInitFile` with the conventional `$peace_dir/init.yaml`
+/// path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceInitFile(PathBuf);
+
+crate::paths::pathbuf_newtype!(WorkspaceInitFile);
+
+impl WorkspaceInitFile {
+    /// File name of the initialization parameters file.
+    pub const NAME: &'static str = "init.yaml";
+}
+
+impl From<&PeaceDir> for WorkspaceInitFile {
+    fn from(flow_dir: &PeaceDir) -> Self {
+        let path = flow_dir.join(Self::NAME);
+
+        Self(path)
+    }
+}

--- a/crate/rt/Cargo.toml
+++ b/crate/rt/Cargo.toml
@@ -16,18 +16,18 @@ doctest = false
 test = false
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.24"
 peace_cfg = { path = "../cfg", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
 peace_rt_model = { path = "../rt_model", version = "0.0.2" }
 peace_rt_model_core = { path = "../rt_model_core", version = "0.0.2" }
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.20.0", features = ["fs", "io-util"] }
-tokio-util = { version = "0.7.3", features = ["io", "io-util"] }
+tokio = { version = "1.21.1", features = ["fs", "io-util"] }
+tokio-util = { version = "0.7.4", features = ["io", "io-util"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 peace_rt_model_web = { path = "../rt_model_web", version = "0.0.2" }
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
-web-sys = { version = "0.3.59", features = ["Storage", "Window"] }
+wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+web-sys = { version = "0.3.60", features = ["Storage", "Window"] }

--- a/crate/rt/src/cmds/ensure_cmd.rs
+++ b/crate/rt/src/cmds/ensure_cmd.rs
@@ -18,12 +18,9 @@ use peace_rt_model::{
 use crate::cmds::{sub::StatesCurrentDiscoverCmd, DiffCmd};
 
 #[derive(Debug)]
-pub struct EnsureCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct EnsureCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    EnsureCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> EnsureCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
     O: OutputWrite<E>,
@@ -53,8 +50,8 @@ where
     /// [`ItemSpec`]: peace_cfg::ItemSpec
     /// [`EnsureOpSpec`]: peace_cfg::ItemSpec::EnsureOpSpec
     pub async fn exec_dry(
-        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, EnsuredDry>, E> {
+        cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, EnsuredDry>, E> {
         let (workspace, item_spec_graph, output, resources, states_type_regs) =
             cmd_context.into_inner();
         let resources_result =
@@ -98,18 +95,14 @@ where
     ) -> Result<Resources<EnsuredDry>, E> {
         // https://github.com/rust-lang/rust-clippy/issues/9111
         #[allow(clippy::needless_borrow)]
-        let resources = DiffCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-            item_spec_graph,
-            resources,
-            &states_type_regs,
-        )
-        .await?;
+        let resources =
+            DiffCmd::<E, O>::exec_internal(item_spec_graph, resources, &states_type_regs).await?;
         let op_check_statuses = Self::ensure_op_spec_check(item_spec_graph, &resources).await?;
         Self::ensure_op_spec_exec_dry(item_spec_graph, &resources, &op_check_statuses).await?;
 
         // TODO: This fetches the real state, whereas for a dry run, it would be useful
         // to show the imagined altered state.
-        let states_current = StatesCurrentDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal_for_ensure_dry(
+        let states_current = StatesCurrentDiscoverCmd::<E, O>::exec_internal_for_ensure_dry(
             item_spec_graph,
             &resources,
         )
@@ -159,8 +152,8 @@ where
     /// [`ItemSpec`]: peace_cfg::ItemSpec
     /// [`EnsureOpSpec`]: peace_cfg::ItemSpec::EnsureOpSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, Ensured>, E> {
+        cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, Ensured>, E> {
         let (workspace, item_spec_graph, output, resources, states_type_regs) =
             cmd_context.into_inner();
         // https://github.com/rust-lang/rust-clippy/issues/9111
@@ -205,16 +198,12 @@ where
     ) -> Result<Resources<Ensured>, E> {
         // https://github.com/rust-lang/rust-clippy/issues/9111
         #[allow(clippy::needless_borrow)]
-        let mut resources = DiffCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-            item_spec_graph,
-            resources,
-            &states_type_regs,
-        )
-        .await?;
+        let mut resources =
+            DiffCmd::<E, O>::exec_internal(item_spec_graph, resources, &states_type_regs).await?;
         let op_check_statuses = Self::ensure_op_spec_check(item_spec_graph, &resources).await?;
         Self::ensure_op_spec_exec(item_spec_graph, &resources, &op_check_statuses).await?;
 
-        let states_current = StatesCurrentDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal_for_ensure(
+        let states_current = StatesCurrentDiscoverCmd::<E, O>::exec_internal_for_ensure(
             item_spec_graph,
             &mut resources,
         )

--- a/crate/rt/src/cmds/states_current_display_cmd.rs
+++ b/crate/rt/src/cmds/states_current_display_cmd.rs
@@ -11,9 +11,12 @@ use crate::cmds::sub::StatesCurrentReadCmd;
 
 /// Displays [`StatesCurrent`]s from storage.
 #[derive(Debug)]
-pub struct StatesCurrentDisplayCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesCurrentDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesCurrentDisplayCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesCurrentDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
     O: OutputWrite<E>,
@@ -26,8 +29,8 @@ where
     /// [`StatesCurrentDiscoverCmd`]: crate::StatesCurrentDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStates>, E> {
+        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
         let CmdContext {
             output,
             resources,
@@ -35,11 +38,12 @@ where
             ..
         } = &mut cmd_context;
 
-        let states_current_result = StatesCurrentReadCmd::<E, O>::exec_internal(
-            resources,
-            states_type_regs.states_current_type_reg(),
-        )
-        .await;
+        let states_current_result =
+            StatesCurrentReadCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
+                resources,
+                states_type_regs.states_current_type_reg(),
+            )
+            .await;
 
         match states_current_result {
             Ok(states_current) => {

--- a/crate/rt/src/cmds/states_current_display_cmd.rs
+++ b/crate/rt/src/cmds/states_current_display_cmd.rs
@@ -57,3 +57,9 @@ where
         }
     }
 }
+
+impl<E, O> Default for StatesCurrentDisplayCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/states_current_display_cmd.rs
+++ b/crate/rt/src/cmds/states_current_display_cmd.rs
@@ -11,12 +11,9 @@ use crate::cmds::sub::StatesCurrentReadCmd;
 
 /// Displays [`StatesCurrent`]s from storage.
 #[derive(Debug)]
-pub struct StatesCurrentDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesCurrentDisplayCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesCurrentDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesCurrentDisplayCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
     O: OutputWrite<E>,
@@ -29,8 +26,8 @@ where
     /// [`StatesCurrentDiscoverCmd`]: crate::StatesCurrentDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
+        mut cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStates>, E> {
         let CmdContext {
             output,
             resources,
@@ -38,12 +35,11 @@ where
             ..
         } = &mut cmd_context;
 
-        let states_current_result =
-            StatesCurrentReadCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-                resources,
-                states_type_regs.states_current_type_reg(),
-            )
-            .await;
+        let states_current_result = StatesCurrentReadCmd::<E, O>::exec_internal(
+            resources,
+            states_type_regs.states_current_type_reg(),
+        )
+        .await;
 
         match states_current_result {
             Ok(states_current) => {

--- a/crate/rt/src/cmds/states_desired_display_cmd.rs
+++ b/crate/rt/src/cmds/states_desired_display_cmd.rs
@@ -11,12 +11,9 @@ use crate::cmds::sub::StatesDesiredReadCmd;
 
 /// Displays [`StatesDesired`]s from storage.
 #[derive(Debug)]
-pub struct StatesDesiredDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesDesiredDisplayCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesDesiredDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesDesiredDisplayCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
     O: OutputWrite<E>,
@@ -29,9 +26,8 @@ where
     /// [`StatesDesiredDiscoverCmd`]: crate::StatesDesiredDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
-    {
+        mut cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStatesDesired>, E> {
         let CmdContext {
             output,
             resources,
@@ -39,12 +35,11 @@ where
             ..
         } = &mut cmd_context;
 
-        let states_desired_result =
-            StatesDesiredReadCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-                resources,
-                states_type_regs.states_desired_type_reg(),
-            )
-            .await;
+        let states_desired_result = StatesDesiredReadCmd::<E, O>::exec_internal(
+            resources,
+            states_type_regs.states_desired_type_reg(),
+        )
+        .await;
 
         match states_desired_result {
             Ok(states_desired) => {

--- a/crate/rt/src/cmds/states_desired_display_cmd.rs
+++ b/crate/rt/src/cmds/states_desired_display_cmd.rs
@@ -11,9 +11,12 @@ use crate::cmds::sub::StatesDesiredReadCmd;
 
 /// Displays [`StatesDesired`]s from storage.
 #[derive(Debug)]
-pub struct StatesDesiredDisplayCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesDesiredDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesDesiredDisplayCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesDesiredDisplayCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
     O: OutputWrite<E>,
@@ -26,8 +29,9 @@ where
     /// [`StatesDesiredDiscoverCmd`]: crate::StatesDesiredDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStatesDesired>, E> {
+        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
+    {
         let CmdContext {
             output,
             resources,
@@ -35,11 +39,12 @@ where
             ..
         } = &mut cmd_context;
 
-        let states_desired_result = StatesDesiredReadCmd::<E, O>::exec_internal(
-            resources,
-            states_type_regs.states_desired_type_reg(),
-        )
-        .await;
+        let states_desired_result =
+            StatesDesiredReadCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
+                resources,
+                states_type_regs.states_desired_type_reg(),
+            )
+            .await;
 
         match states_desired_result {
             Ok(states_desired) => {

--- a/crate/rt/src/cmds/states_desired_display_cmd.rs
+++ b/crate/rt/src/cmds/states_desired_display_cmd.rs
@@ -57,3 +57,9 @@ where
         }
     }
 }
+
+impl<E, O> Default for StatesDesiredDisplayCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -54,3 +54,9 @@ where
         Ok(cmd_context)
     }
 }
+
+impl<E, O> Default for StatesDiscoverCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -10,9 +10,12 @@ use peace_rt_model::CmdContext;
 use crate::cmds::sub::{StatesCurrentDiscoverCmd, StatesDesiredDiscoverCmd};
 
 #[derive(Debug)]
-pub struct StatesDiscoverCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesDiscoverCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -30,16 +33,25 @@ where
     /// [`StateCurrentFnSpec`]: peace_cfg::ItemSpec::StateCurrentFnSpec
     /// [`StateDesiredFnSpec`]: peace_cfg::ItemSpec::StateDesiredFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStatesCurrentAndDesired>, E> {
+        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<
+        CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesCurrentAndDesired>,
+        E,
+    > {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states =
-            StatesCurrentDiscoverCmd::<E, O>::exec_internal(item_spec_graph, &mut resources)
-                .await?;
+            StatesCurrentDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
+                item_spec_graph,
+                &mut resources,
+            )
+            .await?;
         let states_desired =
-            StatesDesiredDiscoverCmd::<E, O>::exec_internal(item_spec_graph, &mut resources)
-                .await?;
+            StatesDesiredDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
+                item_spec_graph,
+                &mut resources,
+            )
+            .await?;
 
         let resources =
             Resources::<WithStatesCurrentAndDesired>::from((resources, states, states_desired));

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -10,12 +10,9 @@ use peace_rt_model::CmdContext;
 use crate::cmds::sub::{StatesCurrentDiscoverCmd, StatesDesiredDiscoverCmd};
 
 #[derive(Debug)]
-pub struct StatesDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesDiscoverCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesDiscoverCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -33,25 +30,16 @@ where
     /// [`StateCurrentFnSpec`]: peace_cfg::ItemSpec::StateCurrentFnSpec
     /// [`StateDesiredFnSpec`]: peace_cfg::ItemSpec::StateDesiredFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<
-        CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesCurrentAndDesired>,
-        E,
-    > {
+        cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStatesCurrentAndDesired>, E> {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states =
-            StatesCurrentDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-                item_spec_graph,
-                &mut resources,
-            )
-            .await?;
+            StatesCurrentDiscoverCmd::<E, O>::exec_internal(item_spec_graph, &mut resources)
+                .await?;
         let states_desired =
-            StatesDesiredDiscoverCmd::<E, O, WorkspaceInit, ProfileInit, FlowInit>::exec_internal(
-                item_spec_graph,
-                &mut resources,
-            )
-            .await?;
+            StatesDesiredDiscoverCmd::<E, O>::exec_internal(item_spec_graph, &mut resources)
+                .await?;
 
         let resources =
             Resources::<WithStatesCurrentAndDesired>::from((resources, states, states_desired));

--- a/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
@@ -186,3 +186,9 @@ where
         Ok(())
     }
 }
+
+impl<E, O> Default for StatesCurrentDiscoverCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
@@ -13,12 +13,9 @@ use peace_rt_model::{CmdContext, Error, ItemSpecGraph, Storage};
 use crate::BUFFERED_FUTURES_MAX;
 
 #[derive(Debug)]
-pub struct StatesCurrentDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesCurrentDiscoverCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesCurrentDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesCurrentDiscoverCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -37,8 +34,8 @@ where
     /// [`ItemSpec`]: peace_cfg::ItemSpec
     /// [`StateCurrentFnSpec`]: peace_cfg::ItemSpec::StateCurrentFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
+        cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStates>, E> {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states = Self::exec_internal(item_spec_graph, &mut resources).await?;

--- a/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
@@ -13,9 +13,12 @@ use peace_rt_model::{CmdContext, Error, ItemSpecGraph, Storage};
 use crate::BUFFERED_FUTURES_MAX;
 
 #[derive(Debug)]
-pub struct StatesCurrentDiscoverCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesCurrentDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesCurrentDiscoverCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesCurrentDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -34,8 +37,8 @@ where
     /// [`ItemSpec`]: peace_cfg::ItemSpec
     /// [`StateCurrentFnSpec`]: peace_cfg::ItemSpec::StateCurrentFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStates>, E> {
+        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states = Self::exec_internal(item_spec_graph, &mut resources).await?;

--- a/crate/rt/src/cmds/sub/states_current_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_read_cmd.rs
@@ -12,9 +12,12 @@ use peace_rt_model::{CmdContext, Error, Storage};
 
 /// Reads [`StatesCurrent`]s from storage.
 #[derive(Debug)]
-pub struct StatesCurrentReadCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesCurrentReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesCurrentReadCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesCurrentReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -26,8 +29,8 @@ where
     /// [`StatesCurrentDiscoverCmd`]: crate::StatesCurrentDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStates>, E> {
+        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
         let CmdContext {
             resources,
             states_type_regs,

--- a/crate/rt/src/cmds/sub/states_current_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_read_cmd.rs
@@ -120,3 +120,9 @@ where
         Ok(states_current)
     }
 }
+
+impl<E, O> Default for StatesCurrentReadCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/sub/states_current_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_read_cmd.rs
@@ -12,12 +12,9 @@ use peace_rt_model::{CmdContext, Error, Storage};
 
 /// Reads [`StatesCurrent`]s from storage.
 #[derive(Debug)]
-pub struct StatesCurrentReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesCurrentReadCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesCurrentReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesCurrentReadCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -29,8 +26,8 @@ where
     /// [`StatesCurrentDiscoverCmd`]: crate::StatesCurrentDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStates>, E> {
+        mut cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStates>, E> {
         let CmdContext {
             resources,
             states_type_regs,

--- a/crate/rt/src/cmds/sub/states_current_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_read_cmd.rs
@@ -103,7 +103,7 @@ where
 
         let states_current_file_str = states_current_file.to_string_lossy();
         let states_serialized = storage
-            .get_item(states_current_file_str.as_ref())?
+            .get_item_opt(states_current_file_str.as_ref())?
             .ok_or(Error::StatesCurrentDiscoverRequired)?;
         let deserializer = serde_yaml::Deserializer::from_str(&states_serialized);
         let states_current = StatesCurrent::from(

--- a/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
@@ -13,9 +13,12 @@ use peace_rt_model::{CmdContext, Error, ItemSpecGraph, Storage};
 use crate::BUFFERED_FUTURES_MAX;
 
 #[derive(Debug)]
-pub struct StatesDesiredDiscoverCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesDesiredDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesDesiredDiscoverCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesDesiredDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -36,8 +39,9 @@ where
     /// [`StatesDesired`]: peace_resources::StatesDesired
     /// [`StateDesiredFnSpec`]: peace_cfg::ItemSpec::StateDesiredFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStatesDesired>, E> {
+        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
+    {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states_desired = Self::exec_internal(item_spec_graph, &mut resources).await?;

--- a/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
@@ -13,12 +13,9 @@ use peace_rt_model::{CmdContext, Error, ItemSpecGraph, Storage};
 use crate::BUFFERED_FUTURES_MAX;
 
 #[derive(Debug)]
-pub struct StatesDesiredDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesDesiredDiscoverCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesDesiredDiscoverCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesDesiredDiscoverCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -39,9 +36,8 @@ where
     /// [`StatesDesired`]: peace_resources::StatesDesired
     /// [`StateDesiredFnSpec`]: peace_cfg::ItemSpec::StateDesiredFnSpec
     pub async fn exec(
-        cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
-    {
+        cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStatesDesired>, E> {
         let (workspace, item_spec_graph, output, mut resources, states_type_regs) =
             cmd_context.into_inner();
         let states_desired = Self::exec_internal(item_spec_graph, &mut resources).await?;

--- a/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
@@ -131,3 +131,9 @@ where
         Ok(())
     }
 }
+
+impl<E, O> Default for StatesDesiredDiscoverCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
@@ -12,9 +12,12 @@ use peace_rt_model::{CmdContext, Error, Storage};
 
 /// Reads [`StatesDesired`]s from storage.
 #[derive(Debug)]
-pub struct StatesDesiredReadCmd<E, O>(PhantomData<(E, O)>);
+pub struct StatesDesiredReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
+);
 
-impl<E, O> StatesDesiredReadCmd<E, O>
+impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
+    StatesDesiredReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -26,8 +29,9 @@ where
     /// [`StatesDesiredDiscoverCmd`]: crate::StatesDesiredDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, SetUp>,
-    ) -> Result<CmdContext<E, O, WithStatesDesired>, E> {
+        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
+    {
         let CmdContext {
             resources,
             states_type_regs,

--- a/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
@@ -103,7 +103,7 @@ where
 
         let states_desired_file_str = states_desired_file.to_string_lossy();
         let states_serialized = storage
-            .get_item(states_desired_file_str.as_ref())?
+            .get_item_opt(states_desired_file_str.as_ref())?
             .ok_or(Error::StatesDesiredDiscoverRequired)?;
         let deserializer = serde_yaml::Deserializer::from_str(&states_serialized);
         let states_desired = StatesDesired::from(

--- a/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
@@ -120,3 +120,9 @@ where
         Ok(states_desired)
     }
 }
+
+impl<E, O> Default for StatesDesiredReadCmd<E, O> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}

--- a/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_read_cmd.rs
@@ -12,12 +12,9 @@ use peace_rt_model::{CmdContext, Error, Storage};
 
 /// Reads [`StatesDesired`]s from storage.
 #[derive(Debug)]
-pub struct StatesDesiredReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>(
-    PhantomData<(E, O, WorkspaceInit, ProfileInit, FlowInit)>,
-);
+pub struct StatesDesiredReadCmd<E, O>(PhantomData<(E, O)>);
 
-impl<E, O, WorkspaceInit, ProfileInit, FlowInit>
-    StatesDesiredReadCmd<E, O, WorkspaceInit, ProfileInit, FlowInit>
+impl<E, O> StatesDesiredReadCmd<E, O>
 where
     E: std::error::Error + From<Error> + Send,
 {
@@ -29,9 +26,8 @@ where
     /// [`StatesDesiredDiscoverCmd`]: crate::StatesDesiredDiscoverCmd
     /// [`StatesDiscoverCmd`]: crate::StatesDiscoverCmd
     pub async fn exec(
-        mut cmd_context: CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, SetUp>,
-    ) -> Result<CmdContext<'_, E, O, WorkspaceInit, ProfileInit, FlowInit, WithStatesDesired>, E>
-    {
+        mut cmd_context: CmdContext<'_, E, O, SetUp>,
+    ) -> Result<CmdContext<'_, E, O, WithStatesDesired>, E> {
         let CmdContext {
             resources,
             states_type_regs,

--- a/crate/rt_model/Cargo.toml
+++ b/crate/rt_model/Cargo.toml
@@ -16,14 +16,14 @@ doctest = false
 test = false
 
 [dependencies]
-fn_graph = { version = "0.5.2", features = ["resman"] }
-futures = "0.3.21"
+fn_graph = { version = "0.5.4", features = ["resman"] }
+futures = "0.3.24"
 peace_cfg = { path = "../cfg", version = "0.0.2" }
 peace_data = { path = "../data", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
 peace_rt_model_core = { path = "../rt_model_core", version = "0.0.2" }
-serde = "1.0.139"
-serde_yaml = "0.8.26"
+serde = "1.0.145"
+serde_yaml = "0.9.13"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 peace_rt_model_native = { path = "../rt_model_native", version = "0.0.2" }

--- a/crate/rt_model/src/cmd_context.rs
+++ b/crate/rt_model/src/cmd_context.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use peace_resources::Resources;
+use peace_resources::{resources_type_state::SetUp, Resources};
 
 use crate::{CmdContextBuilder, ItemSpecGraph, StatesTypeRegs, Workspace};
 
@@ -75,7 +75,7 @@ pub struct CmdContext<'ctx, E, O, TS> {
     pub(crate) marker: PhantomData<()>,
 }
 
-impl<'ctx, E, O, TS> CmdContext<'ctx, E, O, TS>
+impl<'ctx, E, O> CmdContext<'ctx, E, O, SetUp>
 where
     E: std::error::Error,
 {
@@ -95,7 +95,12 @@ where
     ) -> CmdContextBuilder<'ctx, E, O, (), (), ()> {
         CmdContextBuilder::new(workspace, item_spec_graph, output)
     }
+}
 
+impl<'ctx, E, O, TS> CmdContext<'ctx, E, O, TS>
+where
+    E: std::error::Error,
+{
     /// Returns the underlying data.
     pub fn into_inner(
         self,

--- a/crate/rt_model/src/cmd_context_builder.rs
+++ b/crate/rt_model/src/cmd_context_builder.rs
@@ -381,10 +381,12 @@ where
             *profile_init_params =
             WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::profile_init_params_deserialize(storage, profile_init_file).await?;
         }
-        Ok(if flow_init_params.is_none() {
+        if flow_init_params.is_none() {
             *flow_init_params =
             WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::flow_init_params_deserialize(storage, flow_init_file).await?;
-        })
+        }
+
+        Ok(())
     }
 
     /// Serializes init params to storage.
@@ -413,14 +415,16 @@ where
             )
             .await?;
         }
-        Ok(if let Some(flow_init_params) = flow_init_params {
+        if let Some(flow_init_params) = flow_init_params {
             WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::flow_init_params_serialize(
                 storage,
                 flow_init_params,
                 flow_init_file,
             )
             .await?;
-        })
+        }
+
+        Ok(())
     }
 }
 

--- a/crate/rt_model/src/cmd_context_builder.rs
+++ b/crate/rt_model/src/cmd_context_builder.rs
@@ -1,0 +1,448 @@
+use std::{fmt, marker::PhantomData};
+
+use futures::{StreamExt, TryStreamExt};
+use peace_resources::{
+    internal::{FlowInitFile, ProfileInitFile, WorkspaceInitFile},
+    resources_type_state::{Empty, SetUp},
+    Resources,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{CmdContext, Error, ItemSpecGraph, StatesTypeRegs, Workspace, WorkspaceInitializer};
+
+/// Information needed to execute a command.
+///
+/// This includes:
+///
+/// * `ItemSpecGraph`: Logic to run.
+/// * `Resources`: Data consumed / produced by the command.
+///
+/// Members of `Workspace` -- where the command should be run -- are
+/// individually stored in `Resources`:
+///
+/// * [`Profile`]
+/// * [`WorkspaceDir`]
+/// * [`PeaceDir`]
+/// * [`ProfileDir`]
+/// * [`ProfileHistoryDir`]
+///
+/// # Type Parameters
+///
+/// * `E`: Consumer provided error type.
+/// * `O`: `OutputWrite` to return values / errors to.
+/// * `WorkspaceInit`: Parameters to initialize the workspace.
+///
+///     These are parameters common to the workspace. Examples:
+///
+///     - Organization username.
+///     - Repository URL for multiple environments.
+///
+///     This may be `()` if there are no parameters common to the workspace.
+///
+/// * `ProfileInit`: Parameters to initialize the profile.
+///
+///     These are parameters specific to a profile, but common to flows within
+///     that profile. Examples:
+///
+///     - Environment specific credentials.
+///     - URL to publish / download an artifact.
+///
+///     This may be `()` if there are no profile specific parameters.
+///
+/// * `FlowInit`: Parameters to initialize the flow.
+///
+///     These are parameters specific to a flow. Examples:
+///
+///     - Configuration to skip warnings for the particular flow.
+///
+///     This may be `()` if there are no flow specific parameters.
+///
+/// [`Profile`]: peace_cfg::Profile
+/// [`WorkspaceDir`]: peace::resources::paths::WorkspaceDir
+/// [`PeaceDir`]: peace::resources::paths::PeaceDir
+/// [`ProfileDir`]: peace::resources::paths::ProfileDir
+/// [`ProfileHistoryDir`]: peace::resources::paths::ProfileHistoryDir
+#[derive(Debug)]
+pub struct CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInit> {
+    /// Workspace that the `peace` tool runs in.
+    workspace: &'ctx Workspace,
+    /// Graph of item specs.
+    item_spec_graph: &'ctx ItemSpecGraph<E>,
+    /// `OutputWrite` to return values / errors to.
+    output: &'ctx mut O,
+    /// Workspace initialization parameters.
+    workspace_init_params: Option<WorkspaceInit>,
+    /// Profile initialization parameters.
+    profile_init_params: Option<ProfileInit>,
+    /// Flow initialization parameters.
+    flow_init_params: Option<FlowInit>,
+}
+
+impl<'ctx, E, O> CmdContextBuilder<'ctx, E, O, (), (), ()>
+where
+    E: std::error::Error,
+{
+    /// Returns a builder for the command context.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace`: Defines how to discover the workspace.
+    /// * `item_spec_graph`: Logic to run in the command.
+    /// * `output`: [`OutputWrite`] to return values or errors.
+    ///
+    /// [`OutputWrite`]: peace_rt_model_core::OutputWrite
+    pub fn new(
+        workspace: &'ctx Workspace,
+        item_spec_graph: &'ctx ItemSpecGraph<E>,
+        output: &'ctx mut O,
+    ) -> Self {
+        Self {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params: None,
+            profile_init_params: None,
+            flow_init_params: None,
+        }
+    }
+}
+
+impl<'ctx, E, O, ProfileInit, FlowInit> CmdContextBuilder<'ctx, E, O, (), ProfileInit, FlowInit>
+where
+    E: std::error::Error,
+    ProfileInit: Clone + fmt::Debug + Send + Sync + 'static,
+    FlowInit: Clone + fmt::Debug + Send + Sync + 'static,
+{
+    /// Sets the workspace initialization parameters.
+    ///
+    /// Type state enforces that this can only be set once.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_init_next`: The parameters to initialize the workspace.
+    pub fn with_workspace_init<WorkspaceInitNext>(
+        self,
+        workspace_init_next: WorkspaceInitNext,
+    ) -> CmdContextBuilder<'ctx, E, O, WorkspaceInitNext, ProfileInit, FlowInit>
+    where
+        WorkspaceInitNext: Clone + fmt::Debug + Send + Sync + 'static,
+    {
+        let CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params: _,
+            profile_init_params,
+            flow_init_params,
+        } = self;
+
+        CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params: Some(workspace_init_next),
+            profile_init_params,
+            flow_init_params,
+        }
+    }
+}
+
+impl<'ctx, E, O, WorkspaceInit, FlowInit> CmdContextBuilder<'ctx, E, O, WorkspaceInit, (), FlowInit>
+where
+    E: std::error::Error,
+    WorkspaceInit: Clone + fmt::Debug + Send + Sync + 'static,
+    FlowInit: Clone + fmt::Debug + Send + Sync + 'static,
+{
+    /// Sets the profile initialization parameters.
+    ///
+    /// Type state enforces that this can only be set once.
+    ///
+    /// # Parameters
+    ///
+    /// * `profile_init_next`: The parameters to initialize the profile.
+    pub fn with_profile_init<ProfileInitNext>(
+        self,
+        profile_init_next: ProfileInitNext,
+    ) -> CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInitNext, FlowInit>
+    where
+        ProfileInitNext: Clone + fmt::Debug + Send + Sync + 'static,
+    {
+        let CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params,
+            profile_init_params: _,
+            flow_init_params,
+        } = self;
+
+        CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params,
+            profile_init_params: Some(profile_init_next),
+            flow_init_params,
+        }
+    }
+}
+
+impl<'ctx, E, O, WorkspaceInit, ProfileInit>
+    CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInit, ()>
+where
+    E: std::error::Error,
+    WorkspaceInit: Clone + fmt::Debug + Send + Sync + 'static,
+    ProfileInit: Clone + fmt::Debug + Send + Sync + 'static,
+{
+    /// Sets the flow initialization parameters.
+    ///
+    /// Type state enforces that this can only be set once.
+    ///
+    /// # Parameters
+    ///
+    /// * `flow_init_next`: The parameters to initialize the flow.
+    pub fn with_flow_init<FlowInitNext>(
+        self,
+        flow_init_next: FlowInitNext,
+    ) -> CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInitNext>
+    where
+        FlowInitNext: Clone + fmt::Debug + Send + Sync + 'static,
+    {
+        let CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params: _,
+        } = self;
+
+        CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params: Some(flow_init_next),
+        }
+    }
+}
+
+impl<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInit>
+    CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInit>
+where
+    E: std::error::Error + From<Error>,
+    WorkspaceInit: Clone + fmt::Debug + DeserializeOwned + Serialize + Send + Sync + 'static,
+    ProfileInit: Clone + fmt::Debug + DeserializeOwned + Serialize + Send + Sync + 'static,
+    FlowInit: Clone + fmt::Debug + DeserializeOwned + Serialize + Send + Sync + 'static,
+{
+    /// Prepares a workspace to run commands in.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_init_params`: Initialization parameters for the workspace.
+    /// * `profile_init_params`: Initialization parameters for the profile.
+    /// * `flow_init_params`: Initialization parameters for the flow.
+    pub async fn build(self) -> Result<CmdContext<'ctx, E, O, SetUp>, E> {
+        let CmdContextBuilder {
+            workspace,
+            item_spec_graph,
+            output,
+            mut workspace_init_params,
+            mut profile_init_params,
+            mut flow_init_params,
+        } = self;
+
+        let dirs = workspace.dirs();
+        let storage = workspace.storage();
+        let workspace_init_file = WorkspaceInitFile::from(dirs.peace_dir());
+        let profile_init_file = ProfileInitFile::from(dirs.profile_dir());
+        let flow_init_file = FlowInitFile::from(dirs.flow_dir());
+
+        // Read existing init params from storage.
+        Self::init_params_deserialize(
+            storage,
+            &mut workspace_init_params,
+            &workspace_init_file,
+            &mut profile_init_params,
+            &profile_init_file,
+            &mut flow_init_params,
+            &flow_init_file,
+        )
+        .await?;
+
+        // Create directories and write init parameters to storage.
+        #[cfg(target = "wasm32")]
+        WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::dirs_initialize(
+            storage, dirs,
+        )
+        .await?;
+        #[cfg(not(target = "wasm32"))]
+        WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::dirs_initialize(dirs).await?;
+        Self::init_params_serialize(
+            storage,
+            workspace_init_params.as_ref(),
+            &workspace_init_file,
+            profile_init_params.as_ref(),
+            &profile_init_file,
+            flow_init_params.as_ref(),
+            &flow_init_file,
+        )
+        .await?;
+
+        // Track items in memory.
+        let mut resources = Resources::new();
+        Self::workspace_dirs_insert(&mut resources, workspace);
+        resources.insert(workspace_init_file);
+        resources.insert(profile_init_file);
+        resources.insert(flow_init_file);
+        Self::init_params_insert(
+            &mut resources,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        );
+
+        // Call each `ItemSpec`'s initialization function.
+        let resources = Self::item_spec_graph_setup(item_spec_graph, resources).await?;
+        let states_type_regs = Self::states_type_regs(item_spec_graph);
+
+        Ok(CmdContext {
+            workspace,
+            item_spec_graph,
+            output,
+            resources,
+            states_type_regs,
+            marker: PhantomData,
+        })
+    }
+
+    /// Inserts workspace directory resources into the `Resources` map.
+    fn workspace_dirs_insert(resources: &mut Resources<Empty>, workspace: &Workspace) {
+        let (workspace_dirs, profile, flow_id, storage) = workspace.clone().into_inner();
+        let (workspace_dir, peace_dir, profile_dir, profile_history_dir, flow_dir) =
+            workspace_dirs.into_inner();
+
+        resources.insert(workspace_dir);
+        resources.insert(peace_dir);
+        resources.insert(profile_dir);
+        resources.insert(profile_history_dir);
+        resources.insert(flow_dir);
+
+        resources.insert(profile);
+        resources.insert(flow_id);
+        resources.insert(storage);
+    }
+
+    /// Inserts init params into the `Resources` map.
+    fn init_params_insert(
+        resources: &mut Resources<Empty>,
+        workspace_init_params: Option<WorkspaceInit>,
+        profile_init_params: Option<ProfileInit>,
+        flow_init_params: Option<FlowInit>,
+    ) {
+        if let Some(workspace_init_params) = workspace_init_params {
+            resources.insert(workspace_init_params);
+        }
+        if let Some(profile_init_params) = profile_init_params {
+            resources.insert(profile_init_params);
+        }
+        if let Some(flow_init_params) = flow_init_params {
+            resources.insert(flow_init_params);
+        }
+    }
+
+    async fn init_params_deserialize(
+        storage: &peace_rt_model_native::NativeStorage,
+        workspace_init_params: &mut Option<WorkspaceInit>,
+        workspace_init_file: &WorkspaceInitFile,
+        profile_init_params: &mut Option<ProfileInit>,
+        profile_init_file: &ProfileInitFile,
+        flow_init_params: &mut Option<FlowInit>,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<(), E> {
+        if workspace_init_params.is_none() {
+            *workspace_init_params =
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::workspace_init_params_deserialize(storage, workspace_init_file)
+                .await?
+        };
+        if profile_init_params.is_none() {
+            *profile_init_params =
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::profile_init_params_deserialize(storage, profile_init_file).await?;
+        }
+        Ok(if flow_init_params.is_none() {
+            *flow_init_params =
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::flow_init_params_deserialize(storage, flow_init_file).await?;
+        })
+    }
+
+    /// Serializes init params to storage.
+    async fn init_params_serialize(
+        storage: &peace_rt_model_native::NativeStorage,
+        workspace_init_params: Option<&WorkspaceInit>,
+        workspace_init_file: &WorkspaceInitFile,
+        profile_init_params: Option<&ProfileInit>,
+        profile_init_file: &ProfileInitFile,
+        flow_init_params: Option<&FlowInit>,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<(), E> {
+        if let Some(workspace_init_params) = workspace_init_params {
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::workspace_init_params_serialize(
+                storage,
+                workspace_init_params,
+                workspace_init_file,
+            )
+            .await?;
+        }
+        if let Some(profile_init_params) = profile_init_params {
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::profile_init_params_serialize(
+                storage,
+                profile_init_params,
+                profile_init_file,
+            )
+            .await?;
+        }
+        Ok(if let Some(flow_init_params) = flow_init_params {
+            WorkspaceInitializer::<WorkspaceInit, ProfileInit, FlowInit>::flow_init_params_serialize(
+                storage,
+                flow_init_params,
+                flow_init_file,
+            )
+            .await?;
+        })
+    }
+}
+
+impl<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInit>
+    CmdContextBuilder<'ctx, E, O, WorkspaceInit, ProfileInit, FlowInit>
+where
+    E: std::error::Error,
+{
+    /// Registers each item spec's `State` and `StateLogical` for
+    /// deserialization.
+    fn states_type_regs(item_spec_graph: &ItemSpecGraph<E>) -> StatesTypeRegs {
+        item_spec_graph
+            .iter()
+            .fold(StatesTypeRegs::new(), |mut states_type_regs, item_spec| {
+                item_spec.state_register(&mut states_type_regs);
+
+                states_type_regs
+            })
+    }
+
+    async fn item_spec_graph_setup(
+        item_spec_graph: &ItemSpecGraph<E>,
+        resources: Resources<Empty>,
+    ) -> Result<Resources<SetUp>, E> {
+        let resources = item_spec_graph
+            .stream()
+            .map(Ok::<_, E>)
+            .try_fold(resources, |mut resources, item_spec| async move {
+                item_spec.setup(&mut resources).await?;
+                Ok(resources)
+            })
+            .await?;
+
+        Ok(Resources::<SetUp>::from(resources))
+    }
+}

--- a/crate/rt_model/src/item_spec_boxed.rs
+++ b/crate/rt_model/src/item_spec_boxed.rs
@@ -32,16 +32,12 @@ pub struct ItemSpecBoxed<E>(Box<dyn ItemSpecRt<E>>);
 impl<E> Deref for ItemSpecBoxed<E> {
     type Target = dyn ItemSpecRt<E>;
 
-    // https://github.com/rust-lang/rust-clippy/issues/9101
-    #[allow(clippy::explicit_auto_deref)]
     fn deref(&self) -> &Self::Target {
         &*self.0
     }
 }
 
 impl<E> DerefMut for ItemSpecBoxed<E> {
-    // https://github.com/rust-lang/rust-clippy/issues/9101
-    #[allow(clippy::explicit_auto_deref)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.0
     }

--- a/crate/rt_model/src/lib.rs
+++ b/crate/rt_model/src/lib.rs
@@ -8,24 +8,26 @@ pub use fn_graph::{self, FnRef, FnRefMut};
 pub use peace_rt_model_core::OutputWrite;
 
 pub use crate::{
-    cmd_context::CmdContext, in_memory_text_output::InMemoryTextOutput,
-    item_spec_boxed::ItemSpecBoxed, item_spec_graph::ItemSpecGraph,
-    item_spec_graph_builder::ItemSpecGraphBuilder, item_spec_rt::ItemSpecRt,
-    item_spec_wrapper::ItemSpecWrapper, states_type_regs::StatesTypeRegs,
+    cmd_context::CmdContext, cmd_context_builder::CmdContextBuilder,
+    in_memory_text_output::InMemoryTextOutput, item_spec_boxed::ItemSpecBoxed,
+    item_spec_graph::ItemSpecGraph, item_spec_graph_builder::ItemSpecGraphBuilder,
+    item_spec_rt::ItemSpecRt, item_spec_wrapper::ItemSpecWrapper, states_type_regs::StatesTypeRegs,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use peace_rt_model_native::{
     CliOutput, Error, NativeStorage as Storage, SyncIoBridge, Workspace, WorkspaceDirsBuilder,
-    WorkspaceSpec,
+    WorkspaceInitializer, WorkspaceSpec,
 };
 
 #[cfg(target_arch = "wasm32")]
 pub use peace_rt_model_web::{
-    Error, WebStorage as Storage, Workspace, WorkspaceDirsBuilder, WorkspaceSpec,
+    Error, WebStorage as Storage, Workspace, WorkspaceDirsBuilder, WorkspaceInitializer,
+    WorkspaceSpec,
 };
 
 mod cmd_context;
+mod cmd_context_builder;
 mod in_memory_text_output;
 mod item_spec_boxed;
 mod item_spec_graph;

--- a/crate/rt_model_core/Cargo.toml
+++ b/crate/rt_model_core/Cargo.toml
@@ -16,5 +16,5 @@ doctest = false
 test = false
 
 [dependencies]
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 peace_resources = { path = "../resources", version = "0.0.2" }

--- a/crate/rt_model_native/Cargo.toml
+++ b/crate/rt_model_native/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.21"
 peace_core = { path = "../core", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
 peace_rt_model_core = { path = "../rt_model_core", version = "0.0.2" }
+serde = "1.0.139"
 serde_yaml = "0.8.26"
 thiserror = "1.0.31"
 tokio = { version = "1.20.0", features = ["fs", "io-std"] }

--- a/crate/rt_model_native/Cargo.toml
+++ b/crate/rt_model_native/Cargo.toml
@@ -16,12 +16,12 @@ doctest = false
 test = false
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.24"
 peace_core = { path = "../core", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
 peace_rt_model_core = { path = "../rt_model_core", version = "0.0.2" }
-serde = "1.0.139"
-serde_yaml = "0.8.26"
-thiserror = "1.0.31"
-tokio = { version = "1.20.0", features = ["fs", "io-std"] }
-tokio-util = { version = "0.7.3", features = ["io", "io-util"] }
+serde = "1.0.145"
+serde_yaml = "0.9.13"
+thiserror = "1.0.35"
+tokio = { version = "1.21.1", features = ["fs", "io-std"] }
+tokio-util = { version = "0.7.4", features = ["io", "io-util"] }

--- a/crate/rt_model_native/src/error.rs
+++ b/crate/rt_model_native/src/error.rs
@@ -43,6 +43,25 @@ pub enum Error {
     #[error("Failed to serialize ensured states.")]
     StatesEnsuredSerialize(#[source] serde_yaml::Error),
 
+    /// Failed to serialize workspace init params.
+    #[error("Failed to serialize workspace init params.")]
+    WorkspaceInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize workspace init params.
+    #[error("Failed to serialize workspace init params.")]
+    WorkspaceInitParamsDeserialize(#[source] serde_yaml::Error),
+    /// Failed to serialize profile init params.
+    #[error("Failed to serialize profile init params.")]
+    ProfileInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize profile init params.
+    #[error("Failed to serialize profile init params.")]
+    ProfileInitParamsDeserialize(#[source] serde_yaml::Error),
+    /// Failed to serialize flow init params.
+    #[error("Failed to serialize flow init params.")]
+    FlowInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize flow init params.
+    #[error("Failed to serialize flow init params.")]
+    FlowInitParamsDeserialize(#[source] serde_yaml::Error),
+
     // Native errors.
     /// Failed to create file for writing.
     #[error("Failed to create file for writing: `{path}`")]

--- a/crate/rt_model_native/src/error.rs
+++ b/crate/rt_model_native/src/error.rs
@@ -62,6 +62,13 @@ pub enum Error {
     #[error("Failed to serialize flow init params.")]
     FlowInitParamsDeserialize(#[source] serde_yaml::Error),
 
+    /// Item does not exist in storage.
+    #[error("Item does not exist in storage: `{}`.", path.display())]
+    ItemNotExistent {
+        /// Path to the file.
+        path: PathBuf,
+    },
+
     // Native errors.
     /// Failed to create file for writing.
     #[error("Failed to create file for writing: `{path}`")]

--- a/crate/rt_model_native/src/lib.rs
+++ b/crate/rt_model_native/src/lib.rs
@@ -8,7 +8,8 @@ pub use tokio_util::io::SyncIoBridge;
 
 pub use crate::{
     cli_output::CliOutput, error::Error, native_storage::NativeStorage, workspace::Workspace,
-    workspace_dirs_builder::WorkspaceDirsBuilder, workspace_spec::WorkspaceSpec,
+    workspace_dirs_builder::WorkspaceDirsBuilder, workspace_initializer::WorkspaceInitializer,
+    workspace_spec::WorkspaceSpec,
 };
 
 mod cli_output;
@@ -16,4 +17,5 @@ mod error;
 mod native_storage;
 mod workspace;
 mod workspace_dirs_builder;
+mod workspace_initializer;
 mod workspace_spec;

--- a/crate/rt_model_native/src/native_storage.rs
+++ b/crate/rt_model_native/src/native_storage.rs
@@ -1,5 +1,6 @@
 use std::{io::Write, path::Path, sync::Mutex};
 
+use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
     fs::File,
     io::{BufReader, BufWriter},
@@ -13,6 +14,59 @@ use crate::Error;
 pub struct NativeStorage;
 
 impl NativeStorage {
+    /// Reads a serializable item from the given path.
+    ///
+    /// # Parameters
+    ///
+    /// * `thread_name`: Name of the thread to use to do the read operation.
+    /// * `file_path`: Path to the file to read the serialized item.
+    /// * `f_map_err`: Maps the deserialization error (if any) to an [`Error`].
+    pub async fn serialized_read<T, F>(
+        &self,
+        thread_name: String,
+        file_path: &Path,
+        f_map_err: F,
+    ) -> Result<T, Error>
+    where
+        T: Serialize + DeserializeOwned + Send + Sync,
+        F: FnOnce(serde_yaml::Error) -> Error + Send,
+    {
+        let t = self
+            .read_with_sync_api(thread_name, file_path, |file| {
+                serde_yaml::from_reader::<_, T>(file).map_err(f_map_err)
+            })
+            .await?;
+
+        Ok(t)
+    }
+
+    /// Writes a serializable item to the given path.
+    ///
+    /// # Parameters
+    ///
+    /// * `thread_name`: Name of the thread to use to do the write operation.
+    /// * `file_path`: Path to the file to store the serialized item.
+    /// * `t`: Item to serialize.
+    /// * `f_map_err`: Maps the serialization error (if any) to an [`Error`].
+    pub async fn serialized_write<T, F>(
+        &self,
+        thread_name: String,
+        file_path: &Path,
+        t: &T,
+        f_map_err: F,
+    ) -> Result<(), Error>
+    where
+        T: Serialize + DeserializeOwned + Send + Sync,
+        F: FnOnce(serde_yaml::Error) -> Error + Send,
+    {
+        self.write_with_sync_api(thread_name, file_path, |file| {
+            serde_yaml::to_writer(file, t).map_err(f_map_err)
+        })
+        .await?;
+
+        Ok(())
+    }
+
     /// Reads from a file, bridging to libraries that take a synchronous `Write`
     /// type.
     ///
@@ -58,6 +112,13 @@ impl NativeStorage {
     ///
     /// This method buffers the write, and calls flush on the buffer when the
     /// passed in closure returns.
+    ///
+    /// # Parameters
+    ///
+    /// * `thread_name`: Name of the thread to use to do the write operation.
+    /// * `file_path`: Path to the file to store the serialized item.
+    /// * `f`: Function that is given the `Write` implementation to call the
+    ///   sync API with.
     pub async fn write_with_sync_api<'f, F, T>(
         &self,
         thread_name: String,

--- a/crate/rt_model_native/src/workspace.rs
+++ b/crate/rt_model_native/src/workspace.rs
@@ -24,7 +24,7 @@ impl Workspace {
     /// * `workspace_spec`: Defines how to discover the workspace.
     /// * `profile`: The profile / namespace that the execution is flow.
     /// * `flow_id`: ID of the flow that is being executed.
-    pub async fn init(
+    pub fn new(
         workspace_spec: WorkspaceSpec,
         profile: Profile,
         flow_id: FlowId,

--- a/crate/rt_model_native/src/workspace.rs
+++ b/crate/rt_model_native/src/workspace.rs
@@ -1,47 +1,11 @@
-use std::{iter, path::Path};
-
-use futures::{stream, StreamExt, TryStreamExt};
 use peace_core::{FlowId, Profile};
-use peace_resources::{
-    internal::WorkspaceDirs,
-    paths::{FlowDir, PeaceDir, ProfileDir},
-};
-use serde::{de::DeserializeOwned, Serialize};
+use peace_resources::internal::WorkspaceDirs;
 
 use crate::{Error, NativeStorage, WorkspaceDirsBuilder, WorkspaceSpec};
 
 /// Workspace that the `peace` tool runs in.
-///
-/// # Type Parameters
-///
-/// * `WorkspaceInit`: Parameters to initialize the workspace.
-///
-///     These are parameters common to the workspace. Examples:
-///
-///     - Organization username.
-///     - Repository URL for multiple environments.
-///
-///     This may be `()` if there are no parameters common to the workspace.
-///
-/// * `ProfileInit`: Parameters to initialize the profile.
-///
-///     These are parameters specific to a profile, but common to flows within
-///     that profile. Examples:
-///
-///     - Environment specific credentials.
-///     - URL to publish / download an artifact.
-///
-///     This may be `()` if there are no profile specific parameters.
-///
-/// * `FlowInit`: Parameters to initialize the flow.
-///
-///     These are parameters specific to a flow. Examples:
-///
-///     - Configuration to skip warnings for the particular flow.
-///
-///     This may be `()` if there are no flow specific parameters.
 #[derive(Clone, Debug)]
-pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
+pub struct Workspace {
     /// Convention-based directories in this workspace.
     dirs: WorkspaceDirs,
     /// Identifier or namespace to distinguish execution environments.
@@ -50,19 +14,10 @@ pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
     flow_id: FlowId,
     /// File system storage access.
     storage: NativeStorage,
-    /// Workspace initialization parameters.
-    workspace_init_params: WorkspaceInit,
-    /// Profile initialization parameters.
-    profile_init_params: ProfileInit,
-    /// Flow initialization parameters.
-    flow_init_params: FlowInit,
 }
 
-impl Workspace<(), (), ()> {
+impl Workspace {
     /// Prepares a workspace to run commands in.
-    ///
-    /// This is a convenience constructor if your workspace, profile, and flow
-    /// do not need any initialization parameters.
     ///
     /// # Parameters
     ///
@@ -74,233 +29,27 @@ impl Workspace<(), (), ()> {
         profile: Profile,
         flow_id: FlowId,
     ) -> Result<Self, Error> {
-        Self::init_with_params(workspace_spec, profile, flow_id, (), (), ()).await
-    }
-}
-
-impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
-where
-    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync,
-    ProfileInit: Serialize + DeserializeOwned + Send + Sync,
-    FlowInit: Serialize + DeserializeOwned + Send + Sync,
-{
-    /// Prepares a workspace to run commands in.
-    ///
-    /// # Parameters
-    ///
-    /// * `workspace_spec`: Defines how to discover the workspace.
-    /// * `profile`: The profile / namespace that the execution is flow.
-    /// * `flow_id`: ID of the flow that is being executed.
-    /// * `workspace_init_params`: Initialization parameters for the workspace.
-    /// * `profile_init_params`: Initialization parameters for the profile.
-    /// * `flow_init_params`: Initialization parameters for the flow.
-    pub async fn init_with_params(
-        workspace_spec: WorkspaceSpec,
-        profile: Profile,
-        flow_id: FlowId,
-        workspace_init_params: WorkspaceInit,
-        profile_init_params: ProfileInit,
-        flow_init_params: FlowInit,
-    ) -> Result<Self, Error> {
         let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
         let storage = NativeStorage;
-
-        Self::dirs_initialize(&dirs).await?;
-        Self::workspace_init_params_serialize(&storage, &workspace_init_params, dirs.peace_dir())
-            .await?;
-        Self::profile_init_params_serialize(&storage, &profile_init_params, dirs.profile_dir())
-            .await?;
-        Self::flow_init_params_serialize(&storage, &flow_init_params, dirs.flow_dir()).await?;
 
         Ok(Self {
             dirs,
             profile,
             flow_id,
             storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
         })
     }
 
-    /// Prepares a workspace to run commands in.
-    ///
-    /// Initialization parameters must already exist in the `PeaceDir`.
-    ///
-    /// # Parameters
-    ///
-    /// * `workspace_spec`: Defines how to discover the workspace.
-    /// * `profile`: The profile / namespace that the execution is flow.
-    /// * `flow_id`: ID of the flow that is being executed.
-    pub async fn init_from_storage(
-        workspace_spec: WorkspaceSpec,
-        profile: Profile,
-        flow_id: FlowId,
-    ) -> Result<Self, Error> {
-        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
-        let storage = NativeStorage;
-
-        Self::dirs_initialize(&dirs).await?;
-        let workspace_init_params =
-            Self::workspace_init_params_deserialize(&storage, dirs.peace_dir()).await?;
-        let profile_init_params =
-            Self::profile_init_params_deserialize(&storage, dirs.profile_dir()).await?;
-        let flow_init_params =
-            Self::flow_init_params_deserialize(&storage, dirs.flow_dir()).await?;
-
-        Ok(Self {
-            dirs,
-            profile,
-            flow_id,
-            storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
-        })
-    }
-
-    async fn dirs_initialize(dirs: &WorkspaceDirs) -> Result<(), Error> {
-        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(
-                dirs.profile_history_dir(),
-            )))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
-
-        stream::iter(dirs)
-            .map(Result::<_, Error>::Ok)
-            .try_for_each(|dir| async move {
-                tokio::fs::create_dir_all(dir).await.map_err(|error| {
-                    let path = dir.to_path_buf();
-                    Error::WorkspaceDirCreate { path, error }
-                })
-            })
-            .await
-    }
-
-    async fn workspace_init_params_serialize(
-        storage: &NativeStorage,
-        workspace_init_params: &WorkspaceInit,
-        peace_dir: &PeaceDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                "workspace_init_params_serialize".to_string(),
-                &peace_dir,
-                workspace_init_params,
-                Error::WorkspaceInitParamsSerialize,
-            )
-            .await
-    }
-
-    async fn workspace_init_params_deserialize(
-        storage: &NativeStorage,
-        peace_dir: &PeaceDir,
-    ) -> Result<WorkspaceInit, Error> {
-        storage
-            .serialized_read(
-                "workspace_init_params_deserialize".to_string(),
-                &peace_dir,
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn profile_init_params_serialize(
-        storage: &NativeStorage,
-        profile_init_params: &ProfileInit,
-        profile_dir: &ProfileDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                "profile_init_params_serialize".to_string(),
-                &profile_dir,
-                profile_init_params,
-                Error::ProfileInitParamsSerialize,
-            )
-            .await
-    }
-
-    async fn profile_init_params_deserialize(
-        storage: &NativeStorage,
-        profile_dir: &ProfileDir,
-    ) -> Result<ProfileInit, Error> {
-        storage
-            .serialized_read(
-                "profile_init_params_deserialize".to_string(),
-                &profile_dir,
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn flow_init_params_deserialize(
-        storage: &NativeStorage,
-        flow_dir: &FlowDir,
-    ) -> Result<FlowInit, Error> {
-        storage
-            .serialized_read(
-                "flow_init_params_deserialize".to_string(),
-                &flow_dir,
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn flow_init_params_serialize(
-        storage: &NativeStorage,
-        flow_init_params: &FlowInit,
-        flow_dir: &FlowDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                "flow_init_params_serialize".to_string(),
-                &flow_dir,
-                flow_init_params,
-                Error::FlowInitParamsSerialize,
-            )
-            .await
-    }
-}
-
-impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
-where
-    WorkspaceInit: Send + Sync,
-    ProfileInit: Send + Sync,
-    FlowInit: Send + Sync,
-{
     /// Returns the underlying data.
-    pub fn into_inner(
-        self,
-    ) -> (
-        WorkspaceDirs,
-        Profile,
-        FlowId,
-        NativeStorage,
-        WorkspaceInit,
-        ProfileInit,
-        FlowInit,
-    ) {
+    pub fn into_inner(self) -> (WorkspaceDirs, Profile, FlowId, NativeStorage) {
         let Self {
             dirs,
             profile,
             flow_id,
             storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
         } = self;
 
-        (
-            dirs,
-            profile,
-            flow_id,
-            storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
-        )
+        (dirs, profile, flow_id, storage)
     }
 
     /// Returns a reference to the workspace's directories.
@@ -321,20 +70,5 @@ where
     /// Returns a reference to the workspace's storage.
     pub fn storage(&self) -> &NativeStorage {
         &self.storage
-    }
-
-    /// Returns a reference to the workspace init params.
-    pub fn workspace_init_params(&self) -> &WorkspaceInit {
-        &self.workspace_init_params
-    }
-
-    /// Returns a reference to the profile init params.
-    pub fn profile_init_params(&self) -> &ProfileInit {
-        &self.profile_init_params
-    }
-
-    /// Returns a reference to the flow init params.
-    pub fn flow_init_params(&self) -> &FlowInit {
-        &self.flow_init_params
     }
 }

--- a/crate/rt_model_native/src/workspace.rs
+++ b/crate/rt_model_native/src/workspace.rs
@@ -2,14 +2,47 @@ use std::{iter, path::Path};
 
 use futures::{stream, StreamExt, TryStreamExt};
 use peace_core::{FlowId, Profile};
-use peace_resources::internal::WorkspaceDirs;
+use peace_resources::{
+    internal::WorkspaceDirs,
+    paths::{FlowDir, PeaceDir, ProfileDir},
+};
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{Error, NativeStorage, WorkspaceDirsBuilder, WorkspaceSpec};
 
 /// Workspace that the `peace` tool runs in.
+///
+/// # Type Parameters
+///
+/// * `WorkspaceInit`: Parameters to initialize the workspace.
+///
+///     These are parameters common to the workspace. Examples:
+///
+///     - Organization username.
+///     - Repository URL for multiple environments.
+///
+///     This may be `()` if there are no parameters common to the workspace.
+///
+/// * `ProfileInit`: Parameters to initialize the profile.
+///
+///     These are parameters specific to a profile, but common to flows within
+///     that profile. Examples:
+///
+///     - Environment specific credentials.
+///     - URL to publish / download an artifact.
+///
+///     This may be `()` if there are no profile specific parameters.
+///
+/// * `FlowInit`: Parameters to initialize the flow.
+///
+///     These are parameters specific to a flow. Examples:
+///
+///     - Configuration to skip warnings for the particular flow.
+///
+///     This may be `()` if there are no flow specific parameters.
 #[derive(Clone, Debug)]
-pub struct Workspace {
-    /// `Resources` in this workspace.
+pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
+    /// Convention-based directories in this workspace.
     dirs: WorkspaceDirs,
     /// Identifier or namespace to distinguish execution environments.
     profile: Profile,
@@ -17,10 +50,19 @@ pub struct Workspace {
     flow_id: FlowId,
     /// File system storage access.
     storage: NativeStorage,
+    /// Workspace initialization parameters.
+    workspace_init_params: WorkspaceInit,
+    /// Profile initialization parameters.
+    profile_init_params: ProfileInit,
+    /// Flow initialization parameters.
+    flow_init_params: FlowInit,
 }
 
-impl Workspace {
+impl Workspace<(), (), ()> {
     /// Prepares a workspace to run commands in.
+    ///
+    /// This is a convenience constructor if your workspace, profile, and flow
+    /// do not need any initialization parameters.
     ///
     /// # Parameters
     ///
@@ -31,29 +73,234 @@ impl Workspace {
         workspace_spec: WorkspaceSpec,
         profile: Profile,
         flow_id: FlowId,
-    ) -> Result<Workspace, Error> {
-        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
-        Self::initialize_directories(&dirs).await?;
+    ) -> Result<Self, Error> {
+        Self::init_with_params(workspace_spec, profile, flow_id, (), (), ()).await
+    }
+}
 
+impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync,
+    ProfileInit: Serialize + DeserializeOwned + Send + Sync,
+    FlowInit: Serialize + DeserializeOwned + Send + Sync,
+{
+    /// Prepares a workspace to run commands in.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_spec`: Defines how to discover the workspace.
+    /// * `profile`: The profile / namespace that the execution is flow.
+    /// * `flow_id`: ID of the flow that is being executed.
+    /// * `workspace_init_params`: Initialization parameters for the workspace.
+    /// * `profile_init_params`: Initialization parameters for the profile.
+    /// * `flow_init_params`: Initialization parameters for the flow.
+    pub async fn init_with_params(
+        workspace_spec: WorkspaceSpec,
+        profile: Profile,
+        flow_id: FlowId,
+        workspace_init_params: WorkspaceInit,
+        profile_init_params: ProfileInit,
+        flow_init_params: FlowInit,
+    ) -> Result<Self, Error> {
+        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
         let storage = NativeStorage;
-        Ok(Workspace {
+
+        Self::dirs_initialize(&dirs).await?;
+        Self::workspace_init_params_serialize(&storage, &workspace_init_params, dirs.peace_dir())
+            .await?;
+        Self::profile_init_params_serialize(&storage, &profile_init_params, dirs.profile_dir())
+            .await?;
+        Self::flow_init_params_serialize(&storage, &flow_init_params, dirs.flow_dir()).await?;
+
+        Ok(Self {
             dirs,
             profile,
             flow_id,
             storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
         })
     }
 
-    /// Returns the inner data.
-    pub fn into_inner(self) -> (WorkspaceDirs, Profile, FlowId, NativeStorage) {
+    /// Prepares a workspace to run commands in.
+    ///
+    /// Initialization parameters must already exist in the `PeaceDir`.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_spec`: Defines how to discover the workspace.
+    /// * `profile`: The profile / namespace that the execution is flow.
+    /// * `flow_id`: ID of the flow that is being executed.
+    pub async fn init_from_storage(
+        workspace_spec: WorkspaceSpec,
+        profile: Profile,
+        flow_id: FlowId,
+    ) -> Result<Self, Error> {
+        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
+        let storage = NativeStorage;
+
+        Self::dirs_initialize(&dirs).await?;
+        let workspace_init_params =
+            Self::workspace_init_params_deserialize(&storage, dirs.peace_dir()).await?;
+        let profile_init_params =
+            Self::profile_init_params_deserialize(&storage, dirs.profile_dir()).await?;
+        let flow_init_params =
+            Self::flow_init_params_deserialize(&storage, dirs.flow_dir()).await?;
+
+        Ok(Self {
+            dirs,
+            profile,
+            flow_id,
+            storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        })
+    }
+
+    async fn dirs_initialize(dirs: &WorkspaceDirs) -> Result<(), Error> {
+        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(
+                dirs.profile_history_dir(),
+            )))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
+
+        stream::iter(dirs)
+            .map(Result::<_, Error>::Ok)
+            .try_for_each(|dir| async move {
+                tokio::fs::create_dir_all(dir).await.map_err(|error| {
+                    let path = dir.to_path_buf();
+                    Error::WorkspaceDirCreate { path, error }
+                })
+            })
+            .await
+    }
+
+    async fn workspace_init_params_serialize(
+        storage: &NativeStorage,
+        workspace_init_params: &WorkspaceInit,
+        peace_dir: &PeaceDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "workspace_init_params_serialize".to_string(),
+                &peace_dir,
+                workspace_init_params,
+                Error::WorkspaceInitParamsSerialize,
+            )
+            .await
+    }
+
+    async fn workspace_init_params_deserialize(
+        storage: &NativeStorage,
+        peace_dir: &PeaceDir,
+    ) -> Result<WorkspaceInit, Error> {
+        storage
+            .serialized_read(
+                "workspace_init_params_deserialize".to_string(),
+                &peace_dir,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn profile_init_params_serialize(
+        storage: &NativeStorage,
+        profile_init_params: &ProfileInit,
+        profile_dir: &ProfileDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "profile_init_params_serialize".to_string(),
+                &profile_dir,
+                profile_init_params,
+                Error::ProfileInitParamsSerialize,
+            )
+            .await
+    }
+
+    async fn profile_init_params_deserialize(
+        storage: &NativeStorage,
+        profile_dir: &ProfileDir,
+    ) -> Result<ProfileInit, Error> {
+        storage
+            .serialized_read(
+                "profile_init_params_deserialize".to_string(),
+                &profile_dir,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn flow_init_params_deserialize(
+        storage: &NativeStorage,
+        flow_dir: &FlowDir,
+    ) -> Result<FlowInit, Error> {
+        storage
+            .serialized_read(
+                "flow_init_params_deserialize".to_string(),
+                &flow_dir,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn flow_init_params_serialize(
+        storage: &NativeStorage,
+        flow_init_params: &FlowInit,
+        flow_dir: &FlowDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "flow_init_params_serialize".to_string(),
+                &flow_dir,
+                flow_init_params,
+                Error::FlowInitParamsSerialize,
+            )
+            .await
+    }
+}
+
+impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Send + Sync,
+    ProfileInit: Send + Sync,
+    FlowInit: Send + Sync,
+{
+    /// Returns the underlying data.
+    pub fn into_inner(
+        self,
+    ) -> (
+        WorkspaceDirs,
+        Profile,
+        FlowId,
+        NativeStorage,
+        WorkspaceInit,
+        ProfileInit,
+        FlowInit,
+    ) {
         let Self {
             dirs,
             profile,
             flow_id,
             storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
         } = self;
 
-        (dirs, profile, flow_id, storage)
+        (
+            dirs,
+            profile,
+            flow_id,
+            storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        )
     }
 
     /// Returns a reference to the workspace's directories.
@@ -76,23 +323,18 @@ impl Workspace {
         &self.storage
     }
 
-    async fn initialize_directories(dirs: &WorkspaceDirs) -> Result<(), Error> {
-        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(
-                dirs.profile_history_dir(),
-            )))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
+    /// Returns a reference to the workspace init params.
+    pub fn workspace_init_params(&self) -> &WorkspaceInit {
+        &self.workspace_init_params
+    }
 
-        stream::iter(dirs)
-            .map(Result::<_, Error>::Ok)
-            .try_for_each(|dir| async move {
-                tokio::fs::create_dir_all(dir).await.map_err(|error| {
-                    let path = dir.to_path_buf();
-                    Error::WorkspaceDirCreate { path, error }
-                })
-            })
-            .await
+    /// Returns a reference to the profile init params.
+    pub fn profile_init_params(&self) -> &ProfileInit {
+        &self.profile_init_params
+    }
+
+    /// Returns a reference to the flow init params.
+    pub fn flow_init_params(&self) -> &FlowInit {
+        &self.flow_init_params
     }
 }

--- a/crate/rt_model_native/src/workspace_initializer.rs
+++ b/crate/rt_model_native/src/workspace_initializer.rs
@@ -1,0 +1,156 @@
+use std::{iter, marker::PhantomData, path::Path};
+
+use futures::{stream, StreamExt, TryStreamExt};
+
+use peace_resources::internal::{FlowInitFile, ProfileInitFile, WorkspaceDirs, WorkspaceInitFile};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{Error, NativeStorage};
+
+/// Logic to create peace directories and reads/writes initialization params.
+///
+/// # Type Parameters
+///
+/// * `WorkspaceInit`: Parameters to initialize the workspace.
+///
+///     These are parameters common to the workspace. Examples:
+///
+///     - Organization username.
+///     - Repository URL for multiple environments.
+///
+///     This may be `()` if there are no parameters common to the workspace.
+///
+/// * `ProfileInit`: Parameters to initialize the profile.
+///
+///     These are parameters specific to a profile, but common to flows within
+///     that profile. Examples:
+///
+///     - Environment specific credentials.
+///     - URL to publish / download an artifact.
+///
+///     This may be `()` if there are no profile specific parameters.
+///
+/// * `FlowInit`: Parameters to initialize the flow.
+///
+///     These are parameters specific to a flow. Examples:
+///
+///     - Configuration to skip warnings for the particular flow.
+///
+///     This may be `()` if there are no flow specific parameters.
+#[derive(Debug)]
+pub struct WorkspaceInitializer<WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(WorkspaceInit, ProfileInit, FlowInit)>,
+);
+
+impl<WorkspaceInit, ProfileInit, FlowInit>
+    WorkspaceInitializer<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+    ProfileInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+    FlowInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    /// Creates directories used by the peace framework.
+    pub async fn dirs_initialize(dirs: &WorkspaceDirs) -> Result<(), Error> {
+        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(
+                dirs.profile_history_dir(),
+            )))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
+
+        stream::iter(dirs)
+            .map(Result::<_, Error>::Ok)
+            .try_for_each(|dir| async move {
+                tokio::fs::create_dir_all(dir).await.map_err(|error| {
+                    let path = dir.to_path_buf();
+                    Error::WorkspaceDirCreate { path, error }
+                })
+            })
+            .await
+    }
+
+    pub async fn workspace_init_params_serialize(
+        storage: &NativeStorage,
+        workspace_init_params: &WorkspaceInit,
+        workspace_init_file: &WorkspaceInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "workspace_init_params_serialize".to_string(),
+                &workspace_init_file,
+                workspace_init_params,
+                Error::WorkspaceInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn workspace_init_params_deserialize(
+        storage: &NativeStorage,
+        workspace_init_file: &WorkspaceInitFile,
+    ) -> Result<Option<WorkspaceInit>, Error> {
+        storage
+            .serialized_read_opt(
+                "workspace_init_params_deserialize".to_string(),
+                &workspace_init_file,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    pub async fn profile_init_params_serialize(
+        storage: &NativeStorage,
+        profile_init_params: &ProfileInit,
+        profile_init_file: &ProfileInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "profile_init_params_serialize".to_string(),
+                &profile_init_file,
+                profile_init_params,
+                Error::ProfileInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn profile_init_params_deserialize(
+        storage: &NativeStorage,
+        profile_init_file: &ProfileInitFile,
+    ) -> Result<Option<ProfileInit>, Error> {
+        storage
+            .serialized_read_opt(
+                "profile_init_params_deserialize".to_string(),
+                &profile_init_file,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    pub async fn flow_init_params_serialize(
+        storage: &NativeStorage,
+        flow_init_params: &FlowInit,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                "flow_init_params_serialize".to_string(),
+                &flow_init_file,
+                flow_init_params,
+                Error::FlowInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn flow_init_params_deserialize(
+        storage: &NativeStorage,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<Option<FlowInit>, Error> {
+        storage
+            .serialized_read_opt(
+                "flow_init_params_deserialize".to_string(),
+                &flow_init_file,
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+}

--- a/crate/rt_model_native/src/workspace_initializer.rs
+++ b/crate/rt_model_native/src/workspace_initializer.rs
@@ -78,7 +78,7 @@ where
         storage
             .serialized_write(
                 "workspace_init_params_serialize".to_string(),
-                &workspace_init_file,
+                workspace_init_file,
                 workspace_init_params,
                 Error::WorkspaceInitParamsSerialize,
             )
@@ -92,7 +92,7 @@ where
         storage
             .serialized_read_opt(
                 "workspace_init_params_deserialize".to_string(),
-                &workspace_init_file,
+                workspace_init_file,
                 Error::FlowInitParamsDeserialize,
             )
             .await
@@ -106,7 +106,7 @@ where
         storage
             .serialized_write(
                 "profile_init_params_serialize".to_string(),
-                &profile_init_file,
+                profile_init_file,
                 profile_init_params,
                 Error::ProfileInitParamsSerialize,
             )
@@ -120,7 +120,7 @@ where
         storage
             .serialized_read_opt(
                 "profile_init_params_deserialize".to_string(),
-                &profile_init_file,
+                profile_init_file,
                 Error::FlowInitParamsDeserialize,
             )
             .await
@@ -134,7 +134,7 @@ where
         storage
             .serialized_write(
                 "flow_init_params_serialize".to_string(),
-                &flow_init_file,
+                flow_init_file,
                 flow_init_params,
                 Error::FlowInitParamsSerialize,
             )
@@ -148,7 +148,7 @@ where
         storage
             .serialized_read_opt(
                 "flow_init_params_deserialize".to_string(),
-                &flow_init_file,
+                flow_init_file,
                 Error::FlowInitParamsDeserialize,
             )
             .await

--- a/crate/rt_model_web/Cargo.toml
+++ b/crate/rt_model_web/Cargo.toml
@@ -19,6 +19,7 @@ test = false
 peace_core = { path = "../core", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
 thiserror = "1.0.31"
+serde = "1.0.139"
 serde_yaml = "0.8.26"
 wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 web-sys = { version = "0.3.59", features = ["Storage", "Window"] }

--- a/crate/rt_model_web/Cargo.toml
+++ b/crate/rt_model_web/Cargo.toml
@@ -18,8 +18,9 @@ test = false
 [dependencies]
 peace_core = { path = "../core", version = "0.0.2" }
 peace_resources = { path = "../resources", version = "0.0.2" }
-thiserror = "1.0.31"
-serde = "1.0.139"
-serde_yaml = "0.8.26"
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
-web-sys = { version = "0.3.59", features = ["Storage", "Window"] }
+thiserror = "1.0.35"
+serde = "1.0.145"
+serde-wasm-bindgen = "0.4.3"
+serde_yaml = "0.9.13"
+wasm-bindgen = "0.2.83"
+web-sys = { version = "0.3.60", features = ["Storage", "Window"] }

--- a/crate/rt_model_web/src/error.rs
+++ b/crate/rt_model_web/src/error.rs
@@ -60,9 +60,9 @@ pub enum Error {
     #[error("Failed to serialize flow init params.")]
     FlowInitParamsDeserialize(#[source] serde_yaml::Error),
 
-    /// Serialized item does not exist in storage.
-    #[error("Serialized item does not exist in storage: `{key}`.")]
-    SerializedReadNone {
+    /// Item does not exist in storage.
+    #[error("Item does not exist in storage: `{key}`.")]
+    ItemNotExistent {
         /// Key to get.
         key: String,
     },

--- a/crate/rt_model_web/src/error.rs
+++ b/crate/rt_model_web/src/error.rs
@@ -41,6 +41,32 @@ pub enum Error {
     #[error("Failed to serialize ensured states.")]
     StatesEnsuredSerialize(#[source] serde_yaml::Error),
 
+    /// Failed to serialize workspace init params.
+    #[error("Failed to serialize workspace init params.")]
+    WorkspaceInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize workspace init params.
+    #[error("Failed to serialize workspace init params.")]
+    WorkspaceInitParamsDeserialize(#[source] serde_yaml::Error),
+    /// Failed to serialize profile init params.
+    #[error("Failed to serialize profile init params.")]
+    ProfileInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize profile init params.
+    #[error("Failed to serialize profile init params.")]
+    ProfileInitParamsDeserialize(#[source] serde_yaml::Error),
+    /// Failed to serialize flow init params.
+    #[error("Failed to serialize flow init params.")]
+    FlowInitParamsSerialize(#[source] serde_yaml::Error),
+    /// Failed to deserialize flow init params.
+    #[error("Failed to serialize flow init params.")]
+    FlowInitParamsDeserialize(#[source] serde_yaml::Error),
+
+    /// Serialized item does not exist in storage.
+    #[error("Serialized item does not exist in storage: `{key}`.")]
+    SerializedReadNone {
+        /// Key to get.
+        key: String,
+    },
+
     // web_sys related errors
     /// Browser local storage unavailable.
     #[error("Browser local storage unavailable.")]
@@ -67,6 +93,8 @@ pub enum Error {
     #[error("Browser session storage is none.")]
     SessionStorageNone,
     /// Failed to get an item from browser storage.
+    ///
+    /// This failure mode happens when the `get_item` call to the browser fails.
     ///
     /// Note: The original `JsValue` error is converted to a `String` to allow
     /// this type to be `Send`.

--- a/crate/rt_model_web/src/lib.rs
+++ b/crate/rt_model_web/src/lib.rs
@@ -8,13 +8,15 @@
 
 pub use crate::{
     error::Error, web_storage::WebStorage, workspace::Workspace,
-    workspace_dirs_builder::WorkspaceDirsBuilder, workspace_spec::WorkspaceSpec,
+    workspace_dirs_builder::WorkspaceDirsBuilder, workspace_initializer::WorkspaceInitializer,
+    workspace_spec::WorkspaceSpec,
 };
 
 mod error;
 mod web_storage;
 mod workspace;
 mod workspace_dirs_builder;
+mod workspace_initializer;
 mod workspace_spec;
 
 /// Converts the `JsValue` to a `String` to allow `Error` to be `Send`.

--- a/crate/rt_model_web/src/lib.rs
+++ b/crate/rt_model_web/src/lib.rs
@@ -21,7 +21,5 @@ mod workspace_spec;
 
 /// Converts the `JsValue` to a `String` to allow `Error` to be `Send`.
 pub fn stringify_js_value(js_value: wasm_bindgen::JsValue) -> String {
-    js_value
-        .into_serde::<String>()
-        .unwrap_or_else(|_| String::from("<??>"))
+    serde_wasm_bindgen::from_value::<String>(js_value).unwrap_or_else(|_| String::from("<??>"))
 }

--- a/crate/rt_model_web/src/web_storage.rs
+++ b/crate/rt_model_web/src/web_storage.rs
@@ -27,7 +27,7 @@ impl WebStorage {
     /// Returns the browser storage used for the workspace.
     ///
     /// This is the local or session storage depending on the `WorkspaceSpec`
-    /// passed into `Workspace::init`.
+    /// passed into `Workspace::new`.
     ///
     /// `web_sys::Storage` is `!Send`, so cannot be inserted into `Resources`.
     /// As a compromise, we provide this function to fetch the storage when it

--- a/crate/rt_model_web/src/web_storage.rs
+++ b/crate/rt_model_web/src/web_storage.rs
@@ -60,12 +60,18 @@ impl WebStorage {
         Ok(storage)
     }
 
-    /// Gets an item in the web storage.
+    /// Gets an optional item in the web storage.
     ///
-    /// See [`get_items`] if you would like to get multiple items.
+    /// * Use [`get_item_opt`] if you would like to fetch an item that may not
+    ///   exist.
+    /// * Use [`get_items_opt`] if you would like to fetch multiple optional
+    ///   items.
+    /// * Use [`get_item`] if you would like to fetch an item that must exist.
+    /// * Use [`get_items`] if you would like to fetch multiple items that must
+    ///   exist.
     ///
-    /// [`get_items`]: Self::get_items
-    pub fn get_item(&self, key: &str) -> Result<Option<String>, Error> {
+    /// [`get_items_opt`]: Self::get_items
+    pub fn get_item_opt(&self, key: &str) -> Result<Option<String>, Error> {
         let storage = self.get()?;
         storage
             .get_item(key)
@@ -77,10 +83,16 @@ impl WebStorage {
 
     /// Gets multiple items in the web storage.
     ///
-    /// See [`get_item`] if you would like to get a single item.
+    /// * Use [`get_item_opt`] if you would like to fetch an item that may not
+    ///   exist.
+    /// * Use [`get_items_opt`] if you would like to fetch multiple optional
+    ///   items.
+    /// * Use [`get_item`] if you would like to fetch an item that must exist.
+    /// * Use [`get_items`] if you would like to fetch multiple items that must
+    ///   exist.
     ///
     /// [`get_item`]: Self::get_item
-    pub fn get_items<'f, I>(
+    pub fn get_items_opt<'f, I>(
         &self,
         iter: I,
     ) -> Result<impl Iterator<Item = Result<(&'f str, Option<String>), Error>>, Error>
@@ -97,6 +109,70 @@ impl WebStorage {
                     key: key.to_string(),
                     error: crate::stringify_js_value(js_value),
                 })
+        });
+
+        Ok(iter)
+    }
+
+    /// Gets an item in the web storage.
+    ///
+    /// * Use [`get_item_opt`] if you would like to fetch an item that may not
+    ///   exist.
+    /// * Use [`get_items_opt`] if you would like to fetch multiple optional
+    ///   items.
+    /// * Use [`get_item`] if you would like to fetch an item that must exist.
+    /// * Use [`get_items`] if you would like to fetch multiple items that must
+    ///   exist.
+    ///
+    /// [`get_items`]: Self::get_items
+    pub fn get_item(&self, key: &str) -> Result<String, Error> {
+        let storage = self.get()?;
+        storage
+            .get_item(key)
+            .map_err(|js_value| Error::StorageGetItem {
+                key: key.to_string(),
+                error: crate::stringify_js_value(js_value),
+            })
+            .and_then(|value| {
+                value.ok_or_else(|| Error::ItemNotExistent {
+                    key: key.to_string(),
+                })
+            })
+    }
+
+    /// Gets multiple items in the web storage.
+    ///
+    /// * Use [`get_item_opt`] if you would like to fetch an item that may not
+    ///   exist.
+    /// * Use [`get_items_opt`] if you would like to fetch multiple optional
+    ///   items.
+    /// * Use [`get_item`] if you would like to fetch an item that must exist.
+    /// * Use [`get_items`] if you would like to fetch multiple items that must
+    ///   exist.
+    ///
+    /// [`get_item`]: Self::get_item
+    pub fn get_items<'f, I>(
+        &self,
+        iter: I,
+    ) -> Result<impl Iterator<Item = Result<(&'f str, String), Error>>, Error>
+    where
+        I: Iterator<Item = &'f str>,
+    {
+        let storage = self.get()?;
+
+        let iter = iter.map(move |key| {
+            storage
+                .get_item(key)
+                .map_err(|js_value| Error::StorageGetItem {
+                    key: key.to_string(),
+                    error: crate::stringify_js_value(js_value),
+                })
+                .and_then(|value| {
+                    value.ok_or_else(|| Error::ItemNotExistent {
+                        key: key.to_string(),
+                    })
+                })
+                .map(|value| (key, value))
         });
 
         Ok(iter)
@@ -164,16 +240,18 @@ impl WebStorage {
     ///
     /// * `key`: Path to read the serialized item.
     /// * `f_map_err`: Maps the deserialization error (if any) to an [`Error`].
-    pub async fn serialized_read<T, F>(&self, key: &str, f_map_err: F) -> Result<T, Error>
+    pub async fn serialized_read_opt<T, F>(
+        &self,
+        key: &str,
+        f_map_err: F,
+    ) -> Result<Option<T>, Error>
     where
         T: Serialize + DeserializeOwned + Send + Sync,
         F: FnOnce(serde_yaml::Error) -> Error + Send,
     {
-        self.get_item(key)?
-            .ok_or_else(|| Error::SerializedReadNone {
-                key: key.to_string(),
-            })
-            .and_then(|s| serde_yaml::from_str::<T>(&s).map_err(f_map_err))
+        self.get_item_opt(key)?
+            .map(|s| serde_yaml::from_str::<T>(&s).map_err(f_map_err))
+            .transpose()
     }
 
     /// Writes a serializable item to the given key.

--- a/crate/rt_model_web/src/workspace.rs
+++ b/crate/rt_model_web/src/workspace.rs
@@ -32,7 +32,7 @@ impl Workspace {
         let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
         let storage = WebStorage::new(workspace_spec);
 
-        Ok(Workspace {
+        Ok(Self {
             dirs,
             profile,
             flow_id,

--- a/crate/rt_model_web/src/workspace.rs
+++ b/crate/rt_model_web/src/workspace.rs
@@ -1,46 +1,11 @@
-use std::{iter, path::Path};
-
 use peace_core::{FlowId, Profile};
-use peace_resources::{
-    internal::WorkspaceDirs,
-    paths::{FlowDir, PeaceDir, ProfileDir},
-};
-use serde::{de::DeserializeOwned, Serialize};
+use peace_resources::internal::WorkspaceDirs;
 
 use crate::{Error, WebStorage, WorkspaceDirsBuilder, WorkspaceSpec};
 
 /// Workspace that the `peace` tool runs in.
-///
-/// # Type Parameters
-///
-/// * `WorkspaceInit`: Parameters to initialize the workspace.
-///
-///     These are parameters common to the workspace. Examples:
-///
-///     - Organization username.
-///     - Repository URL for multiple environments.
-///
-///     This may be `()` if there are no parameters common to the workspace.
-///
-/// * `ProfileInit`: Parameters to initialize the profile.
-///
-///     These are parameters specific to a profile, but common to flows within
-///     that profile. Examples:
-///
-///     - Environment specific credentials.
-///     - URL to publish / download an artifact.
-///
-///     This may be `()` if there are no profile specific parameters.
-///
-/// * `FlowInit`: Parameters to initialize the flow.
-///
-///     These are parameters specific to a flow. Examples:
-///
-///     - Configuration to skip warnings for the particular flow.
-///
-///     This may be `()` if there are no flow specific parameters.
 #[derive(Clone, Debug)]
-pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
+pub struct Workspace {
     /// `Resources` in this workspace.
     dirs: WorkspaceDirs,
     /// Identifier or namespace to distinguish execution environments.
@@ -49,40 +14,9 @@ pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
     flow_id: FlowId,
     /// Wrapper to retrieve `web_sys::Storage` on demand.
     storage: WebStorage,
-    /// Workspace initialization parameters.
-    workspace_init_params: WorkspaceInit,
-    /// Profile initialization parameters.
-    profile_init_params: ProfileInit,
-    /// Flow initialization parameters.
-    flow_init_params: FlowInit,
 }
 
-impl Workspace<(), (), ()> {
-    /// Prepares a workspace to run commands in.
-    ///
-    /// This is a convenience constructor if your workspace, profile, and flow
-    /// do not need any initialization parameters.
-    ///
-    /// # Parameters
-    ///
-    /// * `workspace_spec`: Defines how to discover the workspace.
-    /// * `profile`: The profile / namespace that the execution is flow.
-    /// * `flow_id`: ID of the flow that is being executed.
-    pub async fn init(
-        workspace_spec: WorkspaceSpec,
-        profile: Profile,
-        flow_id: FlowId,
-    ) -> Result<Self, Error> {
-        Self::init_with_params(workspace_spec, profile, flow_id, (), (), ()).await
-    }
-}
-
-impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
-where
-    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync,
-    ProfileInit: Serialize + DeserializeOwned + Send + Sync,
-    FlowInit: Serialize + DeserializeOwned + Send + Sync,
-{
+impl Workspace {
     /// Prepares a workspace to run commands in.
     ///
     /// # Parameters
@@ -90,47 +24,7 @@ where
     /// * `workspace_spec`: Defines how to discover the workspace.
     /// * `profile`: The profile / namespace that the execution is flow.
     /// * `flow_id`: ID of the flow that is being executed.
-    /// * `workspace_init_params`: Initialization parameters for the workspace.
-    /// * `profile_init_params`: Initialization parameters for the profile.
-    /// * `flow_init_params`: Initialization parameters for the flow.
-    pub async fn init_with_params(
-        workspace_spec: WorkspaceSpec,
-        profile: Profile,
-        flow_id: FlowId,
-        workspace_init_params: WorkspaceInit,
-        profile_init_params: ProfileInit,
-        flow_init_params: FlowInit,
-    ) -> Result<Self, Error> {
-        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
-        let storage = Self::initialize_storage(workspace_spec, &dirs).await?;
-
-        Self::workspace_init_params_serialize(&storage, &workspace_init_params, dirs.peace_dir())
-            .await?;
-        Self::profile_init_params_serialize(&storage, &profile_init_params, dirs.profile_dir())
-            .await?;
-        Self::flow_init_params_serialize(&storage, &flow_init_params, dirs.flow_dir()).await?;
-
-        Ok(Workspace {
-            dirs,
-            profile,
-            flow_id,
-            storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
-        })
-    }
-
-    /// Prepares a workspace to run commands in.
-    ///
-    /// Initialization parameters must already exist in the `PeaceDir`.
-    ///
-    /// # Parameters
-    ///
-    /// * `workspace_spec`: Defines how to discover the workspace.
-    /// * `profile`: The profile / namespace that the execution is flow.
-    /// * `flow_id`: ID of the flow that is being executed.
-    pub async fn init_from_storage(
+    pub fn new(
         workspace_spec: WorkspaceSpec,
         profile: Profile,
         flow_id: FlowId,
@@ -138,164 +32,24 @@ where
         let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
         let storage = WebStorage::new(workspace_spec);
 
-        let workspace_init_params =
-            Self::workspace_init_params_deserialize(&storage, dirs.peace_dir()).await?;
-        let profile_init_params =
-            Self::profile_init_params_deserialize(&storage, dirs.profile_dir()).await?;
-        let flow_init_params =
-            Self::flow_init_params_deserialize(&storage, dirs.flow_dir()).await?;
-
-        Ok(Self {
+        Ok(Workspace {
             dirs,
             profile,
             flow_id,
             storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
         })
     }
 
-    async fn initialize_storage(
-        workspace_spec: WorkspaceSpec,
-        dirs: &WorkspaceDirs,
-    ) -> Result<WebStorage, Error> {
-        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
-            .chain(iter::once(AsRef::<Path>::as_ref(
-                dirs.profile_history_dir(),
-            )))
-            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
-
-        let workspace_storage = WebStorage::new(workspace_spec);
-        workspace_storage.iter_with_storage(dirs, |storage, dir| {
-            let dir_str = dir.to_string_lossy();
-            let value = "";
-            storage
-                .set_item(dir_str.as_ref(), value)
-                .map_err(|js_value| (dir_str.to_string(), "".to_string(), js_value))
-        })?;
-
-        Ok(workspace_storage)
-    }
-
-    async fn workspace_init_params_serialize(
-        storage: &WebStorage,
-        workspace_init_params: &WorkspaceInit,
-        peace_dir: &PeaceDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                &peace_dir.to_string_lossy(),
-                workspace_init_params,
-                Error::WorkspaceInitParamsSerialize,
-            )
-            .await
-    }
-
-    async fn workspace_init_params_deserialize(
-        storage: &WebStorage,
-        peace_dir: &PeaceDir,
-    ) -> Result<WorkspaceInit, Error> {
-        storage
-            .serialized_read(
-                &peace_dir.to_string_lossy(),
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn profile_init_params_serialize(
-        storage: &WebStorage,
-        profile_init_params: &ProfileInit,
-        profile_dir: &ProfileDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                &profile_dir.to_string_lossy(),
-                profile_init_params,
-                Error::ProfileInitParamsSerialize,
-            )
-            .await
-    }
-
-    async fn profile_init_params_deserialize(
-        storage: &WebStorage,
-        profile_dir: &ProfileDir,
-    ) -> Result<ProfileInit, Error> {
-        storage
-            .serialized_read(
-                &profile_dir.to_string_lossy(),
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn flow_init_params_deserialize(
-        storage: &WebStorage,
-        flow_dir: &FlowDir,
-    ) -> Result<FlowInit, Error> {
-        storage
-            .serialized_read(
-                &flow_dir.to_string_lossy(),
-                Error::FlowInitParamsDeserialize,
-            )
-            .await
-    }
-
-    async fn flow_init_params_serialize(
-        storage: &WebStorage,
-        flow_init_params: &FlowInit,
-        flow_dir: &FlowDir,
-    ) -> Result<(), Error> {
-        storage
-            .serialized_write(
-                &flow_dir.to_string_lossy(),
-                flow_init_params,
-                Error::FlowInitParamsSerialize,
-            )
-            .await
-    }
-}
-
-impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
-where
-    WorkspaceInit: Send + Sync,
-    ProfileInit: Send + Sync,
-    FlowInit: Send + Sync,
-{
     /// Returns the underlying data.
-    pub fn into_inner(
-        self,
-    ) -> (
-        WorkspaceDirs,
-        Profile,
-        FlowId,
-        WebStorage,
-        WorkspaceInit,
-        ProfileInit,
-        FlowInit,
-    ) {
+    pub fn into_inner(self) -> (WorkspaceDirs, Profile, FlowId, WebStorage) {
         let Self {
             dirs,
             profile,
             flow_id,
             storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
         } = self;
 
-        (
-            dirs,
-            profile,
-            flow_id,
-            storage,
-            workspace_init_params,
-            profile_init_params,
-            flow_init_params,
-        )
+        (dirs, profile, flow_id, storage)
     }
 
     /// Returns a reference to the workspace's directories.
@@ -316,20 +70,5 @@ where
     /// Returns a reference to the workspace's storage.
     pub fn storage(&self) -> &WebStorage {
         &self.storage
-    }
-
-    /// Returns a reference to the workspace init params.
-    pub fn workspace_init_params(&self) -> &WorkspaceInit {
-        &self.workspace_init_params
-    }
-
-    /// Returns a reference to the profile init params.
-    pub fn profile_init_params(&self) -> &ProfileInit {
-        &self.profile_init_params
-    }
-
-    /// Returns a reference to the flow init params.
-    pub fn flow_init_params(&self) -> &FlowInit {
-        &self.flow_init_params
     }
 }

--- a/crate/rt_model_web/src/workspace.rs
+++ b/crate/rt_model_web/src/workspace.rs
@@ -1,13 +1,46 @@
 use std::{iter, path::Path};
 
 use peace_core::{FlowId, Profile};
-use peace_resources::internal::WorkspaceDirs;
+use peace_resources::{
+    internal::WorkspaceDirs,
+    paths::{FlowDir, PeaceDir, ProfileDir},
+};
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{Error, WebStorage, WorkspaceDirsBuilder, WorkspaceSpec};
 
 /// Workspace that the `peace` tool runs in.
+///
+/// # Type Parameters
+///
+/// * `WorkspaceInit`: Parameters to initialize the workspace.
+///
+///     These are parameters common to the workspace. Examples:
+///
+///     - Organization username.
+///     - Repository URL for multiple environments.
+///
+///     This may be `()` if there are no parameters common to the workspace.
+///
+/// * `ProfileInit`: Parameters to initialize the profile.
+///
+///     These are parameters specific to a profile, but common to flows within
+///     that profile. Examples:
+///
+///     - Environment specific credentials.
+///     - URL to publish / download an artifact.
+///
+///     This may be `()` if there are no profile specific parameters.
+///
+/// * `FlowInit`: Parameters to initialize the flow.
+///
+///     These are parameters specific to a flow. Examples:
+///
+///     - Configuration to skip warnings for the particular flow.
+///
+///     This may be `()` if there are no flow specific parameters.
 #[derive(Clone, Debug)]
-pub struct Workspace {
+pub struct Workspace<WorkspaceInit, ProfileInit, FlowInit> {
     /// `Resources` in this workspace.
     dirs: WorkspaceDirs,
     /// Identifier or namespace to distinguish execution environments.
@@ -16,10 +49,19 @@ pub struct Workspace {
     flow_id: FlowId,
     /// Wrapper to retrieve `web_sys::Storage` on demand.
     storage: WebStorage,
+    /// Workspace initialization parameters.
+    workspace_init_params: WorkspaceInit,
+    /// Profile initialization parameters.
+    profile_init_params: ProfileInit,
+    /// Flow initialization parameters.
+    flow_init_params: FlowInit,
 }
 
-impl Workspace {
+impl Workspace<(), (), ()> {
     /// Prepares a workspace to run commands in.
+    ///
+    /// This is a convenience constructor if your workspace, profile, and flow
+    /// do not need any initialization parameters.
     ///
     /// # Parameters
     ///
@@ -30,48 +72,88 @@ impl Workspace {
         workspace_spec: WorkspaceSpec,
         profile: Profile,
         flow_id: FlowId,
-    ) -> Result<Workspace, Error> {
+    ) -> Result<Self, Error> {
+        Self::init_with_params(workspace_spec, profile, flow_id, (), (), ()).await
+    }
+}
+
+impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync,
+    ProfileInit: Serialize + DeserializeOwned + Send + Sync,
+    FlowInit: Serialize + DeserializeOwned + Send + Sync,
+{
+    /// Prepares a workspace to run commands in.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_spec`: Defines how to discover the workspace.
+    /// * `profile`: The profile / namespace that the execution is flow.
+    /// * `flow_id`: ID of the flow that is being executed.
+    /// * `workspace_init_params`: Initialization parameters for the workspace.
+    /// * `profile_init_params`: Initialization parameters for the profile.
+    /// * `flow_init_params`: Initialization parameters for the flow.
+    pub async fn init_with_params(
+        workspace_spec: WorkspaceSpec,
+        profile: Profile,
+        flow_id: FlowId,
+        workspace_init_params: WorkspaceInit,
+        profile_init_params: ProfileInit,
+        flow_init_params: FlowInit,
+    ) -> Result<Self, Error> {
         let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
         let storage = Self::initialize_storage(workspace_spec, &dirs).await?;
+
+        Self::workspace_init_params_serialize(&storage, &workspace_init_params, dirs.peace_dir())
+            .await?;
+        Self::profile_init_params_serialize(&storage, &profile_init_params, dirs.profile_dir())
+            .await?;
+        Self::flow_init_params_serialize(&storage, &flow_init_params, dirs.flow_dir()).await?;
 
         Ok(Workspace {
             dirs,
             profile,
             flow_id,
             storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
         })
     }
 
-    /// Returns the inner data.
-    pub fn into_inner(self) -> (WorkspaceDirs, Profile, FlowId, WebStorage) {
-        let Self {
+    /// Prepares a workspace to run commands in.
+    ///
+    /// Initialization parameters must already exist in the `PeaceDir`.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_spec`: Defines how to discover the workspace.
+    /// * `profile`: The profile / namespace that the execution is flow.
+    /// * `flow_id`: ID of the flow that is being executed.
+    pub async fn init_from_storage(
+        workspace_spec: WorkspaceSpec,
+        profile: Profile,
+        flow_id: FlowId,
+    ) -> Result<Self, Error> {
+        let dirs = WorkspaceDirsBuilder::build(workspace_spec, &profile, &flow_id)?;
+        let storage = WebStorage::new(workspace_spec);
+
+        let workspace_init_params =
+            Self::workspace_init_params_deserialize(&storage, dirs.peace_dir()).await?;
+        let profile_init_params =
+            Self::profile_init_params_deserialize(&storage, dirs.profile_dir()).await?;
+        let flow_init_params =
+            Self::flow_init_params_deserialize(&storage, dirs.flow_dir()).await?;
+
+        Ok(Self {
             dirs,
             profile,
             flow_id,
             storage,
-        } = self;
-
-        (dirs, profile, flow_id, storage)
-    }
-
-    /// Returns a reference to the workspace's directories.
-    pub fn dirs(&self) -> &WorkspaceDirs {
-        &self.dirs
-    }
-
-    /// Returns a reference to the workspace's profile.
-    pub fn profile(&self) -> &Profile {
-        &self.profile
-    }
-
-    /// Returns a reference to the workspace's flow ID.
-    pub fn flow_id(&self) -> &FlowId {
-        &self.flow_id
-    }
-
-    /// Returns the storage used for this workspace.
-    pub fn storage(&self) -> &WebStorage {
-        &self.storage
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        })
     }
 
     async fn initialize_storage(
@@ -96,5 +178,158 @@ impl Workspace {
         })?;
 
         Ok(workspace_storage)
+    }
+
+    async fn workspace_init_params_serialize(
+        storage: &WebStorage,
+        workspace_init_params: &WorkspaceInit,
+        peace_dir: &PeaceDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &peace_dir.to_string_lossy(),
+                workspace_init_params,
+                Error::WorkspaceInitParamsSerialize,
+            )
+            .await
+    }
+
+    async fn workspace_init_params_deserialize(
+        storage: &WebStorage,
+        peace_dir: &PeaceDir,
+    ) -> Result<WorkspaceInit, Error> {
+        storage
+            .serialized_read(
+                &peace_dir.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn profile_init_params_serialize(
+        storage: &WebStorage,
+        profile_init_params: &ProfileInit,
+        profile_dir: &ProfileDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &profile_dir.to_string_lossy(),
+                profile_init_params,
+                Error::ProfileInitParamsSerialize,
+            )
+            .await
+    }
+
+    async fn profile_init_params_deserialize(
+        storage: &WebStorage,
+        profile_dir: &ProfileDir,
+    ) -> Result<ProfileInit, Error> {
+        storage
+            .serialized_read(
+                &profile_dir.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn flow_init_params_deserialize(
+        storage: &WebStorage,
+        flow_dir: &FlowDir,
+    ) -> Result<FlowInit, Error> {
+        storage
+            .serialized_read(
+                &flow_dir.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    async fn flow_init_params_serialize(
+        storage: &WebStorage,
+        flow_init_params: &FlowInit,
+        flow_dir: &FlowDir,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &flow_dir.to_string_lossy(),
+                flow_init_params,
+                Error::FlowInitParamsSerialize,
+            )
+            .await
+    }
+}
+
+impl<WorkspaceInit, ProfileInit, FlowInit> Workspace<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Send + Sync,
+    ProfileInit: Send + Sync,
+    FlowInit: Send + Sync,
+{
+    /// Returns the underlying data.
+    pub fn into_inner(
+        self,
+    ) -> (
+        WorkspaceDirs,
+        Profile,
+        FlowId,
+        WebStorage,
+        WorkspaceInit,
+        ProfileInit,
+        FlowInit,
+    ) {
+        let Self {
+            dirs,
+            profile,
+            flow_id,
+            storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        } = self;
+
+        (
+            dirs,
+            profile,
+            flow_id,
+            storage,
+            workspace_init_params,
+            profile_init_params,
+            flow_init_params,
+        )
+    }
+
+    /// Returns a reference to the workspace's directories.
+    pub fn dirs(&self) -> &WorkspaceDirs {
+        &self.dirs
+    }
+
+    /// Returns a reference to the workspace's profile.
+    pub fn profile(&self) -> &Profile {
+        &self.profile
+    }
+
+    /// Returns a reference to the workspace's flow_id.
+    pub fn flow_id(&self) -> &FlowId {
+        &self.flow_id
+    }
+
+    /// Returns a reference to the workspace's storage.
+    pub fn storage(&self) -> &WebStorage {
+        &self.storage
+    }
+
+    /// Returns a reference to the workspace init params.
+    pub fn workspace_init_params(&self) -> &WorkspaceInit {
+        &self.workspace_init_params
+    }
+
+    /// Returns a reference to the profile init params.
+    pub fn profile_init_params(&self) -> &ProfileInit {
+        &self.profile_init_params
+    }
+
+    /// Returns a reference to the flow init params.
+    pub fn flow_init_params(&self) -> &FlowInit {
+        &self.flow_init_params
     }
 }

--- a/crate/rt_model_web/src/workspace_initializer.rs
+++ b/crate/rt_model_web/src/workspace_initializer.rs
@@ -1,0 +1,151 @@
+use std::{iter, marker::PhantomData, path::Path};
+
+use peace_resources::internal::{FlowInitFile, ProfileInitFile, WorkspaceDirs, WorkspaceInitFile};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{Error, WebStorage};
+
+/// Logic to create peace directories and reads/writes initialization params.
+///
+/// # Type Parameters
+///
+/// * `WorkspaceInit`: Parameters to initialize the workspace.
+///
+///     These are parameters common to the workspace. Examples:
+///
+///     - Organization username.
+///     - Repository URL for multiple environments.
+///
+///     This may be `()` if there are no parameters common to the workspace.
+///
+/// * `ProfileInit`: Parameters to initialize the profile.
+///
+///     These are parameters specific to a profile, but common to flows within
+///     that profile. Examples:
+///
+///     - Environment specific credentials.
+///     - URL to publish / download an artifact.
+///
+///     This may be `()` if there are no profile specific parameters.
+///
+/// * `FlowInit`: Parameters to initialize the flow.
+///
+///     These are parameters specific to a flow. Examples:
+///
+///     - Configuration to skip warnings for the particular flow.
+///
+///     This may be `()` if there are no flow specific parameters.
+#[derive(Debug)]
+pub struct WorkspaceInitializer<WorkspaceInit, ProfileInit, FlowInit>(
+    PhantomData<(WorkspaceInit, ProfileInit, FlowInit)>,
+);
+
+impl<WorkspaceInit, ProfileInit, FlowInit>
+    WorkspaceInitializer<WorkspaceInit, ProfileInit, FlowInit>
+where
+    WorkspaceInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+    ProfileInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+    FlowInit: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    /// Creates directories used by the peace framework.
+    ///
+    /// For web storage, this sets empty values at directory paths to emulate
+    /// the native storage.
+    pub async fn dirs_initialize(storage: &WebStorage, dirs: &WorkspaceDirs) -> Result<(), Error> {
+        let dirs = iter::once(AsRef::<Path>::as_ref(dirs.workspace_dir()))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.peace_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.profile_dir())))
+            .chain(iter::once(AsRef::<Path>::as_ref(
+                dirs.profile_history_dir(),
+            )))
+            .chain(iter::once(AsRef::<Path>::as_ref(dirs.flow_dir())));
+
+        storage.iter_with_storage(dirs, |storage, dir| {
+            let dir_str = dir.to_string_lossy();
+            let value = "";
+            storage
+                .set_item(dir_str.as_ref(), value)
+                .map_err(|js_value| (dir_str.to_string(), value.to_string(), js_value))
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn workspace_init_params_serialize(
+        storage: &WebStorage,
+        workspace_init_params: &WorkspaceInit,
+        workspace_init_file: &WorkspaceInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &workspace_init_file.to_string_lossy(),
+                workspace_init_params,
+                Error::WorkspaceInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn workspace_init_params_deserialize(
+        storage: &WebStorage,
+        workspace_init_file: &WorkspaceInitFile,
+    ) -> Result<Option<WorkspaceInit>, Error> {
+        storage
+            .serialized_read_opt(
+                &workspace_init_file.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    pub async fn profile_init_params_serialize(
+        storage: &WebStorage,
+        profile_init_params: &ProfileInit,
+        profile_init_file: &ProfileInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &profile_init_file.to_string_lossy(),
+                profile_init_params,
+                Error::ProfileInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn profile_init_params_deserialize(
+        storage: &WebStorage,
+        profile_init_file: &ProfileInitFile,
+    ) -> Result<Option<ProfileInit>, Error> {
+        storage
+            .serialized_read_opt(
+                &profile_init_file.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+
+    pub async fn flow_init_params_serialize(
+        storage: &WebStorage,
+        flow_init_params: &FlowInit,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<(), Error> {
+        storage
+            .serialized_write(
+                &flow_init_file.to_string_lossy(),
+                flow_init_params,
+                Error::FlowInitParamsSerialize,
+            )
+            .await
+    }
+
+    pub async fn flow_init_params_deserialize(
+        storage: &WebStorage,
+        flow_init_file: &FlowInitFile,
+    ) -> Result<Option<FlowInit>, Error> {
+        storage
+            .serialized_read_opt(
+                &flow_init_file.to_string_lossy(),
+                Error::FlowInitParamsDeserialize,
+            )
+            .await
+    }
+}

--- a/crate/static_check_macros/Cargo.toml
+++ b/crate/static_check_macros/Cargo.toml
@@ -17,6 +17,6 @@ doctest = true
 test = false
 
 [dependencies]
-syn = "1.0.98"
-quote = "1.0.20"
-proc-macro2 = "1.0.43"
+syn = "1.0.100"
+quote = "1.0.21"
+proc-macro2 = "1.0.44"

--- a/examples/download/Cargo.toml
+++ b/examples/download/Cargo.toml
@@ -23,7 +23,7 @@ reqwest = { version = "0.11.11", features = ["stream"] }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_yaml = "0.8.26"
 thiserror = "1.0.31"
-url = "2.2.2"
+url = { version = "2.2.2", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.20.0", features = ["fs", "io-std", "io-util", "rt"] }

--- a/examples/download/Cargo.toml
+++ b/examples/download/Cargo.toml
@@ -14,23 +14,24 @@ test = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bytes = "1.1.0"
-clap = { version = "3.2.16", features = ["derive"] }
+bytes = "1.2.1"
+clap = { version = "3.2.22", features = ["derive"] }
 console_error_panic_hook = "0.1.7"
-futures = "0.3.21"
+futures = "0.3.24"
 peace = { path = "../.." }
-reqwest = { version = "0.11.11", features = ["stream"] }
-serde = { version = "1.0.139", features = ["derive"] }
-serde_yaml = "0.8.26"
-thiserror = "1.0.31"
-url = { version = "2.2.2", features = ["serde"] }
+reqwest = { version = "0.11.12", features = ["stream"] }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_yaml = "0.9.13"
+thiserror = "1.0.35"
+url = { version = "2.3.1", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.20.0", features = ["fs", "io-std", "io-util", "rt"] }
+tokio = { version = "1.21.1", features = ["fs", "io-std", "io-util", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1.20.0", features = ["io-util"] }
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.32"
-js-sys = "0.3.59"
-web-sys = "0.3.59"
+serde-wasm-bindgen = "0.4.3"
+tokio = { version = "1.21.1", features = ["io-util"] }
+wasm-bindgen = "0.2.83"
+wasm-bindgen-futures = "0.4.33"
+js-sys = "0.3.60"
+web-sys = "0.3.60"

--- a/examples/download/index.html
+++ b/examples/download/index.html
@@ -110,7 +110,7 @@
         document.querySelector("#init").addEventListener("click", () => {
           const path = document.querySelector("#path").value;
           const url = document.querySelector("#url").value;
-          exports.wasm_setup(url, path)
+          exports.wasm_init(url, path)
             .then(workspace_and_content => {
               workspace_and_content_global = workspace_and_content;
               update_state(workspace_and_content_global);

--- a/examples/download/src/download_args.rs
+++ b/examples/download/src/download_args.rs
@@ -19,60 +19,26 @@ pub struct DownloadArgs {
 
 #[derive(Subcommand)]
 pub enum DownloadCommand {
+    Init {
+        /// URL to download from.
+        #[clap(value_hint(ValueHint::Url))]
+        url: Url,
+        /// File path to write to.
+        #[clap(value_parser)]
+        dest: PathBuf,
+    },
     /// Fetches the current state and desired state.
-    Fetch {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    Fetch,
     /// Shows the download state.
-    Status {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    Status,
     /// Shows the download state.
-    Desired {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    Desired,
     /// Shows the diff between the remote file and local file state.
     ///
     /// This may not be the full content diff if the file is large.
-    Diff {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    Diff,
     /// Dry-run to execute the download if necessary.
-    EnsureDry {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    EnsureDry,
     /// Executes the download if necessary.
-    Ensure {
-        /// URL to download from.
-        #[clap(value_hint(ValueHint::Url))]
-        url: Url,
-        /// File path to write to.
-        #[clap(value_parser)]
-        dest: PathBuf,
-    },
+    Ensure,
 }

--- a/examples/download/src/download_item_spec.rs
+++ b/examples/download/src/download_item_spec.rs
@@ -4,7 +4,6 @@ use peace::{
     cfg::{async_trait, item_spec_id, ItemSpec, ItemSpecId},
     resources::{resources_type_state::Empty, Resources},
 };
-use url::Url;
 
 use crate::{
     DownloadCleanOpSpec, DownloadEnsureOpSpec, DownloadError, DownloadStateCurrentFnSpec,
@@ -13,21 +12,7 @@ use crate::{
 
 /// Full spec for downloading a file.
 #[derive(Debug)]
-pub struct DownloadItemSpec {
-    /// Url of the file to download.
-    src: Url,
-    /// Path of the destination.
-    ///
-    /// Must be a file path, and not a directory.
-    dest: PathBuf,
-}
-
-impl DownloadItemSpec {
-    /// Returns a new ItemSpec
-    pub fn new(src: Url, dest: PathBuf) -> Self {
-        Self { src, dest }
-    }
-}
+pub struct DownloadItemSpec;
 
 #[async_trait(?Send)]
 impl ItemSpec for DownloadItemSpec {
@@ -47,8 +32,6 @@ impl ItemSpec for DownloadItemSpec {
 
     async fn setup(&self, resources: &mut Resources<Empty>) -> Result<(), DownloadError> {
         resources.insert::<reqwest::Client>(reqwest::Client::new());
-        resources.insert::<Url>(self.src.clone());
-        resources.insert::<PathBuf>(self.dest.clone());
 
         #[cfg(target_arch = "wasm32")]
         resources.insert(std::collections::HashMap::<PathBuf, String>::new());

--- a/examples/download/src/download_profile_init.rs
+++ b/examples/download/src/download_profile_init.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// User parameters for a download profile.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct DownloadProfileInit {
+    /// Url of the file to download.
+    src: Url,
+    /// Path of the destination.
+    ///
+    /// Must be a file path, and not a directory.
+    dest: PathBuf,
+}
+
+impl DownloadProfileInit {
+    /// Returns a new `DownloadProfileInit`.
+    pub fn new(src: Url, dest: PathBuf) -> Self {
+        Self { src, dest }
+    }
+
+    /// Returns the URL to download from.
+    pub fn src(&self) -> &Url {
+        &self.src
+    }
+
+    /// Returns the file path to write to.
+    pub fn dest(&self) -> &PathBuf {
+        &self.dest
+    }
+}

--- a/examples/download/src/download_state_current_fn_spec.rs
+++ b/examples/download/src/download_state_current_fn_spec.rs
@@ -70,7 +70,7 @@ impl FnSpec for DownloadStateCurrentFnSpec {
     type Output = State<Option<FileState>, PathBuf>;
 
     async fn exec(download_params: DownloadParams<'_>) -> Result<Self::Output, DownloadError> {
-        let dest = download_params.dest();
+        let dest = download_params.download_profile_init().dest();
 
         #[cfg(not(target_arch = "wasm32"))]
         let file_exists = dest.exists();

--- a/examples/download/src/download_state_desired_fn_spec.rs
+++ b/examples/download/src/download_state_desired_fn_spec.rs
@@ -13,7 +13,7 @@ impl DownloadStateDesiredFnSpec {
         download_params: &DownloadParams<'_>,
     ) -> Result<FileState, DownloadError> {
         let client = download_params.client();
-        let src_url = download_params.src();
+        let src_url = download_params.download_profile_init().src();
         let response = client
             .get(src_url.clone())
             .send()

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -60,7 +60,7 @@ pub struct WorkspaceAndGraph {
 
 /// Returns a default workspace and the Download item spec graph.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn setup_workspace_and_graph(
+pub async fn workspace_init(
     workspace_spec: WorkspaceSpec,
     profile: Profile,
     flow_id: FlowId,
@@ -68,6 +68,14 @@ pub async fn setup_workspace_and_graph(
     dest: PathBuf,
 ) -> Result<WorkspaceAndGraph, DownloadError> {
     let workspace = Workspace::init(workspace_spec, profile, flow_id).await?;
+
+    // TODO: Maybe params that are fed to ItemSpecGraph, which are automatically
+    // inserted into `Resources`. Params needs to be serialized so that they can
+    // be read from disk automatically.
+    //
+    // May be nice if they are defaulted to nothing so users don't have to specify
+    // them. However, automation usually has parameters.
+
     let item_spec_graph = {
         let mut item_spec_graph_builder = ItemSpecGraphBuilder::<DownloadError>::new();
         item_spec_graph_builder.add_fn(DownloadItemSpec::new(url, dest).into());
@@ -83,7 +91,7 @@ pub async fn setup_workspace_and_graph(
 
 /// Returns a default workspace and the Download item spec graph.
 #[cfg(target_arch = "wasm32")]
-pub async fn setup_workspace_and_graph(
+pub async fn workspace_init(
     workspace_spec: WorkspaceSpec,
     profile: Profile,
     flow_id: FlowId,

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use peace::{
     cfg::{FlowId, Profile},
     resources::{
@@ -16,7 +14,6 @@ use peace::{
         CmdContext, ItemSpecGraph, ItemSpecGraphBuilder, OutputWrite, Workspace, WorkspaceSpec,
     },
 };
-use url::Url;
 
 pub use crate::{
     download_args::{DownloadArgs, DownloadCommand},
@@ -25,6 +22,7 @@ pub use crate::{
     download_error::DownloadError,
     download_item_spec::DownloadItemSpec,
     download_params::DownloadParams,
+    download_profile_init::DownloadProfileInit,
     download_state_current_fn_spec::DownloadStateCurrentFnSpec,
     download_state_desired_fn_spec::DownloadStateDesiredFnSpec,
     download_state_diff_fn_spec::DownloadStateDiffFnSpec,
@@ -38,6 +36,7 @@ mod download_ensure_op_spec;
 mod download_error;
 mod download_item_spec;
 mod download_params;
+mod download_profile_init;
 mod download_state_current_fn_spec;
 mod download_state_desired_fn_spec;
 mod download_state_diff_fn_spec;
@@ -60,25 +59,16 @@ pub struct WorkspaceAndGraph {
 
 /// Returns a default workspace and the Download item spec graph.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn workspace_init(
+pub async fn workspace_and_graph_setup(
     workspace_spec: WorkspaceSpec,
     profile: Profile,
     flow_id: FlowId,
-    url: Url,
-    dest: PathBuf,
 ) -> Result<WorkspaceAndGraph, DownloadError> {
-    let workspace = Workspace::init(workspace_spec, profile, flow_id).await?;
-
-    // TODO: Maybe params that are fed to ItemSpecGraph, which are automatically
-    // inserted into `Resources`. Params needs to be serialized so that they can
-    // be read from disk automatically.
-    //
-    // May be nice if they are defaulted to nothing so users don't have to specify
-    // them. However, automation usually has parameters.
+    let workspace = Workspace::new(workspace_spec, profile, flow_id)?;
 
     let item_spec_graph = {
         let mut item_spec_graph_builder = ItemSpecGraphBuilder::<DownloadError>::new();
-        item_spec_graph_builder.add_fn(DownloadItemSpec::new(url, dest).into());
+        item_spec_graph_builder.add_fn(DownloadItemSpec.into());
         item_spec_graph_builder.build()
     };
 
@@ -91,17 +81,15 @@ pub async fn workspace_init(
 
 /// Returns a default workspace and the Download item spec graph.
 #[cfg(target_arch = "wasm32")]
-pub async fn workspace_init(
+pub async fn workspace_and_graph_setup(
     workspace_spec: WorkspaceSpec,
     profile: Profile,
     flow_id: FlowId,
-    url: Url,
-    dest: PathBuf,
 ) -> Result<WorkspaceAndGraph, DownloadError> {
-    let workspace = Workspace::init(workspace_spec, profile, flow_id).await?;
+    let workspace = Workspace::new(workspace_spec, profile, flow_id)?;
     let item_spec_graph = {
         let mut item_spec_graph_builder = ItemSpecGraphBuilder::<DownloadError>::new();
-        item_spec_graph_builder.add_fn(DownloadItemSpec::new(url, dest).into());
+        item_spec_graph_builder.add_fn(DownloadItemSpec.into());
         item_spec_graph_builder.build()
     };
 
@@ -116,6 +104,7 @@ pub async fn workspace_init(
 pub async fn cmd_context<'ctx, O>(
     workspace_and_graph: &'ctx WorkspaceAndGraph,
     output: &'ctx mut O,
+    download_profile_init: Option<DownloadProfileInit>,
 ) -> Result<CmdContext<'ctx, DownloadError, O, SetUp>, DownloadError>
 where
     O: OutputWrite<DownloadError>,
@@ -124,7 +113,19 @@ where
         workspace,
         item_spec_graph,
     } = workspace_and_graph;
-    CmdContext::builder(workspace, item_spec_graph, output).await
+    CmdContext::builder(workspace, item_spec_graph, output)
+        .with_profile_init(download_profile_init)
+        .await
+}
+
+pub async fn init<O>(
+    cmd_context: CmdContext<'_, DownloadError, O, SetUp>,
+) -> Result<Resources<SetUp>, DownloadError>
+where
+    O: OutputWrite<DownloadError>,
+{
+    let CmdContext { resources, .. } = cmd_context;
+    Ok(resources)
 }
 
 pub async fn fetch<O>(

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -118,16 +118,6 @@ where
         .await
 }
 
-pub async fn init<O>(
-    cmd_context: CmdContext<'_, DownloadError, O, SetUp>,
-) -> Result<Resources<SetUp>, DownloadError>
-where
-    O: OutputWrite<DownloadError>,
-{
-    let CmdContext { resources, .. } = cmd_context;
-    Ok(resources)
-}
-
 pub async fn fetch<O>(
     cmd_context: CmdContext<'_, DownloadError, O, SetUp>,
 ) -> Result<Resources<WithStatesCurrentAndDesired>, DownloadError>

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -124,7 +124,7 @@ where
         workspace,
         item_spec_graph,
     } = workspace_and_graph;
-    CmdContext::init(workspace, item_spec_graph, output).await
+    CmdContext::builder(workspace, item_spec_graph, output).await
 }
 
 pub async fn fetch<O>(

--- a/examples/download/src/main.rs
+++ b/examples/download/src/main.rs
@@ -5,7 +5,7 @@ use peace::{
 };
 
 use download::{
-    cmd_context, desired, diff, ensure, ensure_dry, fetch, init, status, workspace_and_graph_setup,
+    cmd_context, desired, diff, ensure, ensure_dry, fetch, status, workspace_and_graph_setup,
     DownloadArgs, DownloadCommand, DownloadError, DownloadProfileInit,
 };
 
@@ -35,7 +35,7 @@ pub fn main() -> Result<(), DownloadError> {
                     Some(DownloadProfileInit::new(url, dest)),
                 )
                 .await?;
-                init(cmd_context).await?;
+                fetch(cmd_context).await?;
             }
             DownloadCommand::Fetch => {
                 let workspace_and_graph =

--- a/examples/download/src/main.rs
+++ b/examples/download/src/main.rs
@@ -5,8 +5,8 @@ use peace::{
 };
 
 use download::{
-    cmd_context, desired, diff, ensure, ensure_dry, fetch, status, workspace_and_graph_setup,
-    workspace_init, DownloadArgs, DownloadCommand, DownloadError,
+    cmd_context, desired, diff, ensure, ensure_dry, fetch, init, status, workspace_and_graph_setup,
+    DownloadArgs, DownloadCommand, DownloadError, DownloadProfileInit,
 };
 
 pub fn main() -> Result<(), DownloadError> {
@@ -28,44 +28,49 @@ pub fn main() -> Result<(), DownloadError> {
         match command {
             DownloadCommand::Init { url, dest } => {
                 let workspace_and_graph =
-                    workspace_init(workspace_spec, profile, flow_id, url, dest).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
-                fetch(cmd_context).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
+                let cmd_context = cmd_context(
+                    &workspace_and_graph,
+                    &mut cli_output,
+                    Some(DownloadProfileInit::new(url, dest)),
+                )
+                .await?;
+                init(cmd_context).await?;
             }
             DownloadCommand::Fetch => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 fetch(cmd_context).await?;
             }
             DownloadCommand::Status => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 status(cmd_context).await?;
             }
             DownloadCommand::Desired => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 desired(cmd_context).await?;
             }
             DownloadCommand::Diff => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 diff(cmd_context).await?;
             }
             DownloadCommand::EnsureDry => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 ensure_dry(cmd_context).await?;
             }
             DownloadCommand::Ensure => {
                 let workspace_and_graph =
                     workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
-                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output, None).await?;
                 ensure(cmd_context).await?;
             }
         }

--- a/examples/download/src/main.rs
+++ b/examples/download/src/main.rs
@@ -5,8 +5,8 @@ use peace::{
 };
 
 use download::{
-    cmd_context, desired, diff, ensure, ensure_dry, fetch, setup_workspace_and_graph, status,
-    DownloadArgs, DownloadCommand, DownloadError,
+    cmd_context, desired, diff, ensure, ensure_dry, fetch, status, workspace_and_graph_setup,
+    workspace_init, DownloadArgs, DownloadCommand, DownloadError,
 };
 
 pub fn main() -> Result<(), DownloadError> {
@@ -26,39 +26,45 @@ pub fn main() -> Result<(), DownloadError> {
         let mut cli_output = CliOutput::default();
 
         match command {
-            DownloadCommand::Fetch { url, dest } => {
+            DownloadCommand::Init { url, dest } => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_init(workspace_spec, profile, flow_id, url, dest).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 fetch(cmd_context).await?;
             }
-            DownloadCommand::Status { url, dest } => {
+            DownloadCommand::Fetch => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
+                let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
+                fetch(cmd_context).await?;
+            }
+            DownloadCommand::Status => {
+                let workspace_and_graph =
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 status(cmd_context).await?;
             }
-            DownloadCommand::Desired { url, dest } => {
+            DownloadCommand::Desired => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 desired(cmd_context).await?;
             }
-            DownloadCommand::Diff { url, dest } => {
+            DownloadCommand::Diff => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 diff(cmd_context).await?;
             }
-            DownloadCommand::EnsureDry { url, dest } => {
+            DownloadCommand::EnsureDry => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 ensure_dry(cmd_context).await?;
             }
-            DownloadCommand::Ensure { url, dest } => {
+            DownloadCommand::Ensure => {
                 let workspace_and_graph =
-                    setup_workspace_and_graph(workspace_spec, profile, flow_id, url, dest).await?;
+                    workspace_and_graph_setup(workspace_spec, profile, flow_id).await?;
                 let cmd_context = cmd_context(&workspace_and_graph, &mut cli_output).await?;
                 ensure(cmd_context).await?;
             }

--- a/examples/download/src/wasm.rs
+++ b/examples/download/src/wasm.rs
@@ -8,10 +8,11 @@ use url::Url;
 use wasm_bindgen::prelude::*;
 
 pub use crate::{
-    cmd_context, desired, diff, ensure, ensure_dry, fetch, setup_workspace_and_graph, status,
-    DownloadArgs, DownloadCleanOpSpec, DownloadCommand, DownloadEnsureOpSpec, DownloadError,
-    DownloadItemSpec, DownloadParams, DownloadStateCurrentFnSpec, DownloadStateDesiredFnSpec,
-    DownloadStateDiffFnSpec, FileState, FileStateDiff, WorkspaceAndGraph,
+    cmd_context, desired, diff, ensure, ensure_dry, fetch, status, workspace_and_graph_setup,
+    workspace_init, DownloadArgs, DownloadCleanOpSpec, DownloadCommand, DownloadEnsureOpSpec,
+    DownloadError, DownloadItemSpec, DownloadParams, DownloadStateCurrentFnSpec,
+    DownloadStateDesiredFnSpec, DownloadStateDiffFnSpec, FileState, FileStateDiff,
+    WorkspaceAndGraph,
 };
 
 #[wasm_bindgen]
@@ -37,10 +38,10 @@ impl WorkspaceAndContent {
 }
 
 #[wasm_bindgen]
-pub async fn wasm_setup(url: String, name: String) -> Result<WorkspaceAndContent, JsValue> {
+pub async fn wasm_init(url: String, name: String) -> Result<WorkspaceAndContent, JsValue> {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
-    setup_workspace_and_graph(
+    workspace_init(
         WorkspaceSpec::SessionStorage,
         profile!("default"),
         flow_id!("file"),

--- a/examples/download/src/wasm.rs
+++ b/examples/download/src/wasm.rs
@@ -33,7 +33,7 @@ impl WorkspaceAndContent {
     /// Returns the content of the hashmap.
     #[wasm_bindgen]
     pub fn contents(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.content).map_err(into_js_err_value)
+        serde_wasm_bindgen::to_value(&self.content).map_err(into_js_err_value)
     }
 }
 

--- a/workspace_tests/Cargo.toml
+++ b/workspace_tests/Cargo.toml
@@ -19,8 +19,8 @@ test = true
 [dev-dependencies]
 diff-struct = "0.4.2"
 peace = { path = "..", version = "0.0.2" }
-serde = { version = "1.0.139", features = ["derive"] }
-serde_yaml = "0.8.26"
+serde = { version = "1.0.145", features = ["derive"] }
+serde_yaml = "0.9.13"
 tempfile = "3.3.0"
-thiserror = "1.0.31"
-tokio = { version = "1.20.0", features = ["rt", "macros"] }
+thiserror = "1.0.35"
+tokio = { version = "1.21.1", features = ["rt", "macros"] }

--- a/workspace_tests/src/resources/dir/states_current_file.rs
+++ b/workspace_tests/src/resources/dir/states_current_file.rs
@@ -35,7 +35,7 @@ pub fn from_path_buf() {
 }
 
 #[test]
-pub fn from_profile_dir_relative() {
+pub fn from_flow_dir_relative() {
     let peace_dir = PeaceDir::from(Path::new(".").to_path_buf());
     let profile = profile!("test_profile");
     let profile_dir = ProfileDir::from((&peace_dir, &profile));

--- a/workspace_tests/src/resources/dir/states_desired_file.rs
+++ b/workspace_tests/src/resources/dir/states_desired_file.rs
@@ -37,7 +37,7 @@ pub fn from_path_buf() {
 }
 
 #[test]
-pub fn from_profile_dir_relative() {
+pub fn from_flow_dir_relative() {
     let peace_dir = PeaceDir::from(Path::new(".").to_path_buf());
     let profile = profile!("test_profile");
     let profile_dir = ProfileDir::from((&peace_dir, &profile));

--- a/workspace_tests/src/resources/internal.rs
+++ b/workspace_tests/src/resources/internal.rs
@@ -3,3 +3,4 @@ mod profile_init_file;
 mod state_diffs_mut;
 mod states_mut;
 mod workspace_dirs;
+mod workspace_init_file;

--- a/workspace_tests/src/resources/internal.rs
+++ b/workspace_tests/src/resources/internal.rs
@@ -1,3 +1,5 @@
+mod flow_init_file;
+mod profile_init_file;
 mod state_diffs_mut;
 mod states_mut;
 mod workspace_dirs;

--- a/workspace_tests/src/resources/internal/flow_init_file.rs
+++ b/workspace_tests/src/resources/internal/flow_init_file.rs
@@ -1,0 +1,79 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use peace::{
+    cfg::{flow_id, profile, FlowId, Profile},
+    resources::{
+        internal::FlowInitFile,
+        paths::{FlowDir, PeaceDir, ProfileDir},
+    },
+};
+
+#[test]
+pub fn debug() {
+    let flow_init_file = FlowInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        r#"FlowInitFile("init.yaml")"#,
+        format!("{flow_init_file:?}")
+    );
+}
+
+#[test]
+pub fn partial_eq() {
+    let flow_init_file_0 = FlowInitFile::from(Path::new("init.yaml").to_path_buf());
+    let flow_init_file_1 = flow_init_file_0.clone();
+
+    assert_eq!(flow_init_file_0, flow_init_file_1);
+}
+
+#[test]
+pub fn from_path_buf() {
+    let flow_init_file = FlowInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(Path::new("init.yaml"), &*flow_init_file);
+}
+
+#[test]
+pub fn from_flow_dir_relative() {
+    let peace_dir = PeaceDir::from(Path::new(".").to_path_buf());
+    let profile = profile!("test_profile");
+    let profile_dir = ProfileDir::from((&peace_dir, &profile));
+    let flow_dir = FlowDir::from((&profile_dir, &flow_id!("test_flow")));
+    let flow_init_file = FlowInitFile::from(&flow_dir);
+
+    let path = PathBuf::from_iter([".", "test_profile", "test_flow", "init.yaml"]);
+    assert_eq!(path, &*flow_init_file);
+}
+
+#[test]
+pub fn into_inner_returns_path_buf() {
+    let flow_init_file = FlowInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml").to_path_buf(),
+        flow_init_file.into_inner()
+    );
+}
+
+#[test]
+pub fn as_ref_os_str() {
+    let flow_init_file = FlowInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        OsStr::new("init.yaml"),
+        <FlowInitFile as AsRef<OsStr>>::as_ref(&flow_init_file)
+    );
+}
+
+#[test]
+pub fn as_ref_path() {
+    let flow_init_file = FlowInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml"),
+        <FlowInitFile as AsRef<Path>>::as_ref(&flow_init_file)
+    );
+}

--- a/workspace_tests/src/resources/internal/profile_init_file.rs
+++ b/workspace_tests/src/resources/internal/profile_init_file.rs
@@ -1,0 +1,78 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use peace::{
+    cfg::{profile, Profile},
+    resources::{
+        internal::ProfileInitFile,
+        paths::{PeaceDir, ProfileDir},
+    },
+};
+
+#[test]
+pub fn debug() {
+    let profile_init_file = ProfileInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        r#"ProfileInitFile("init.yaml")"#,
+        format!("{profile_init_file:?}")
+    );
+}
+
+#[test]
+pub fn partial_eq() {
+    let profile_init_file_0 = ProfileInitFile::from(Path::new("init.yaml").to_path_buf());
+    let profile_init_file_1 = profile_init_file_0.clone();
+
+    assert_eq!(profile_init_file_0, profile_init_file_1);
+}
+
+#[test]
+pub fn from_path_buf() {
+    let profile_init_file = ProfileInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(Path::new("init.yaml"), &*profile_init_file);
+}
+
+#[test]
+pub fn from_profile_dir_relative() {
+    let peace_dir = PeaceDir::from(Path::new(".").to_path_buf());
+    let profile = profile!("test_profile");
+    let profile_dir = ProfileDir::from((&peace_dir, &profile));
+    let profile_init_file = ProfileInitFile::from(&profile_dir);
+
+    let path = PathBuf::from_iter([".", "test_profile", "init.yaml"]);
+    assert_eq!(path, &*profile_init_file);
+}
+
+#[test]
+pub fn into_inner_returns_path_buf() {
+    let profile_init_file = ProfileInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml").to_path_buf(),
+        profile_init_file.into_inner()
+    );
+}
+
+#[test]
+pub fn as_ref_os_str() {
+    let profile_init_file = ProfileInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        OsStr::new("init.yaml"),
+        <ProfileInitFile as AsRef<OsStr>>::as_ref(&profile_init_file)
+    );
+}
+
+#[test]
+pub fn as_ref_path() {
+    let profile_init_file = ProfileInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml"),
+        <ProfileInitFile as AsRef<Path>>::as_ref(&profile_init_file)
+    );
+}

--- a/workspace_tests/src/resources/internal/workspace_init_file.rs
+++ b/workspace_tests/src/resources/internal/workspace_init_file.rs
@@ -1,0 +1,70 @@
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use peace::resources::{internal::WorkspaceInitFile, paths::PeaceDir};
+
+#[test]
+pub fn debug() {
+    let workspace_init_file = WorkspaceInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        r#"WorkspaceInitFile("init.yaml")"#,
+        format!("{workspace_init_file:?}")
+    );
+}
+
+#[test]
+pub fn partial_eq() {
+    let workspace_init_file_0 = WorkspaceInitFile::from(Path::new("init.yaml").to_path_buf());
+    let workspace_init_file_1 = workspace_init_file_0.clone();
+
+    assert_eq!(workspace_init_file_0, workspace_init_file_1);
+}
+
+#[test]
+pub fn from_path_buf() {
+    let workspace_init_file = WorkspaceInitFile::from(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(Path::new("init.yaml"), &*workspace_init_file);
+}
+
+#[test]
+pub fn from_peace_dir_relative() {
+    let peace_dir = PeaceDir::from(Path::new(".").to_path_buf());
+    let workspace_init_file = WorkspaceInitFile::from(&peace_dir);
+
+    let path = PathBuf::from_iter([".", "init.yaml"]);
+    assert_eq!(path, &*workspace_init_file);
+}
+
+#[test]
+pub fn into_inner_returns_path_buf() {
+    let workspace_init_file = WorkspaceInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml").to_path_buf(),
+        workspace_init_file.into_inner()
+    );
+}
+
+#[test]
+pub fn as_ref_os_str() {
+    let workspace_init_file = WorkspaceInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        OsStr::new("init.yaml"),
+        <WorkspaceInitFile as AsRef<OsStr>>::as_ref(&workspace_init_file)
+    );
+}
+
+#[test]
+pub fn as_ref_path() {
+    let workspace_init_file = WorkspaceInitFile::new(Path::new("init.yaml").to_path_buf());
+
+    assert_eq!(
+        Path::new("init.yaml"),
+        <WorkspaceInitFile as AsRef<Path>>::as_ref(&workspace_init_file)
+    );
+}

--- a/workspace_tests/src/rt/diff_cmd.rs
+++ b/workspace_tests/src/rt/diff_cmd.rs
@@ -26,11 +26,11 @@ async fn contains_state_logical_diff_for_each_item_spec() -> Result<(), Box<dyn 
     let mut no_op_output = NoOpOutput;
 
     // Write current and desired states to disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     StatesDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext { resources, .. } = DiffCmd::exec(cmd_context).await?;
 
     let states = resources.borrow::<StatesCurrent>();
@@ -74,7 +74,7 @@ async fn diff_with_multiple_changes() -> Result<(), Box<dyn std::error::Error>> 
     let mut no_op_output = NoOpOutput;
 
     // Write current and desired states to disk.
-    let mut cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let mut cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     // overwrite initial state
     let resources = cmd_context.resources_mut();
     #[rustfmt::skip]
@@ -83,7 +83,7 @@ async fn diff_with_multiple_changes() -> Result<(), Box<dyn std::error::Error>> 
     StatesDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk.
-    let cmd_context = { CmdContext::init(&workspace, &graph, &mut no_op_output).await? };
+    let cmd_context = { CmdContext::builder(&workspace, &graph, &mut no_op_output).await? };
     let CmdContext { resources, .. } = DiffCmd::exec(cmd_context).await?;
 
     let states = resources.borrow::<StatesCurrent>();

--- a/workspace_tests/src/rt/diff_cmd.rs
+++ b/workspace_tests/src/rt/diff_cmd.rs
@@ -12,12 +12,11 @@ use crate::{NoOpOutput, VecA, VecB, VecCopyError, VecCopyItemSpec};
 async fn contains_state_logical_diff_for_each_item_spec() -> Result<(), Box<dyn std::error::Error>>
 {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -60,12 +59,11 @@ async fn contains_state_logical_diff_for_each_item_spec() -> Result<(), Box<dyn 
 #[tokio::test]
 async fn diff_with_multiple_changes() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/ensure_cmd.rs
+++ b/workspace_tests/src/rt/ensure_cmd.rs
@@ -24,11 +24,11 @@ async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std:
     let mut no_op_output = NoOpOutput;
 
     // Write current and desired states to disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     StatesDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext { resources, .. } = EnsureCmd::exec_dry(cmd_context).await?;
 
     let states = resources.borrow::<StatesCurrent>();
@@ -68,18 +68,18 @@ async fn resources_ensured_contains_state_ensured_for_each_item_spec()
     let mut no_op_output = NoOpOutput;
 
     // Write current and desired states to disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     StatesDiscoverCmd::exec(cmd_context).await?;
 
     // Alter states.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_ensured,
         ..
     } = EnsureCmd::exec(cmd_context).await?;
 
     // Re-read states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_reread,
         ..

--- a/workspace_tests/src/rt/ensure_cmd.rs
+++ b/workspace_tests/src/rt/ensure_cmd.rs
@@ -10,12 +10,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -54,12 +53,11 @@ async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std:
 async fn resources_ensured_contains_state_ensured_for_each_item_spec()
 -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_current_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_current_discover_cmd.rs
@@ -48,3 +48,14 @@ async fn runs_state_current_for_each_item_spec() -> Result<(), Box<dyn std::erro
 
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesCurrentDiscoverCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesCurrentDiscoverCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_current_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_current_discover_cmd.rs
@@ -10,12 +10,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn runs_state_current_for_each_item_spec() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_current_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_current_discover_cmd.rs
@@ -22,7 +22,7 @@ async fn runs_state_current_for_each_item_spec() -> Result<(), Box<dyn std::erro
         graph_builder.build()
     };
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let CmdContext { resources, .. } = StatesCurrentDiscoverCmd::exec(cmd_context).await?;
 

--- a/workspace_tests/src/rt/states_current_display_cmd.rs
+++ b/workspace_tests/src/rt/states_current_display_cmd.rs
@@ -90,3 +90,14 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     );
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesCurrentDisplayCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesCurrentDisplayCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_current_display_cmd.rs
+++ b/workspace_tests/src/rt/states_current_display_cmd.rs
@@ -25,14 +25,14 @@ async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std
 
     // Write current states to disk.
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_discover,
         ..
     } = StatesCurrentDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk in a new set of resources.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut fn_tracker_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut fn_tracker_output).await?;
     let CmdContext {
         resources: resources_from_read,
         ..
@@ -73,7 +73,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     let mut fn_tracker_output = FnTrackerOutput::new();
 
     // Try and display states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut fn_tracker_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut fn_tracker_output).await?;
     let exec_result = StatesCurrentDisplayCmd::exec(cmd_context).await;
 
     assert!(matches!(

--- a/workspace_tests/src/rt/states_current_display_cmd.rs
+++ b/workspace_tests/src/rt/states_current_display_cmd.rs
@@ -10,12 +10,11 @@ use crate::{FnInvocation, FnTrackerOutput, NoOpOutput, VecCopyError, VecCopyItem
 #[tokio::test]
 async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -59,12 +58,11 @@ async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std
 #[tokio::test]
 async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_current_read_cmd.rs
+++ b/workspace_tests/src/rt/states_current_read_cmd.rs
@@ -10,12 +10,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -50,12 +49,11 @@ async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std
 #[tokio::test]
 async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_current_read_cmd.rs
+++ b/workspace_tests/src/rt/states_current_read_cmd.rs
@@ -24,14 +24,14 @@ async fn reads_states_current_from_disk_when_present() -> Result<(), Box<dyn std
     let mut no_op_output = NoOpOutput;
 
     // Write current states to disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_discover,
         ..
     } = StatesCurrentDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk in a new set of resources.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_read,
         ..
@@ -64,7 +64,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
 
     // Try and read states from disk.
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let exec_result = StatesCurrentReadCmd::exec(cmd_context).await;
 
     assert!(matches!(

--- a/workspace_tests/src/rt/states_current_read_cmd.rs
+++ b/workspace_tests/src/rt/states_current_read_cmd.rs
@@ -73,3 +73,14 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     ));
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesCurrentReadCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesCurrentReadCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_desired_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_discover_cmd.rs
@@ -10,12 +10,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn runs_state_desired_for_each_item_spec() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_desired_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_discover_cmd.rs
@@ -48,3 +48,14 @@ async fn runs_state_desired_for_each_item_spec() -> Result<(), Box<dyn std::erro
 
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesDesiredDiscoverCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesDesiredDiscoverCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_desired_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_discover_cmd.rs
@@ -22,7 +22,7 @@ async fn runs_state_desired_for_each_item_spec() -> Result<(), Box<dyn std::erro
         graph_builder.build()
     };
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let CmdContext { resources, .. } = StatesDesiredDiscoverCmd::exec(cmd_context).await?;
 

--- a/workspace_tests/src/rt/states_desired_display_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_display_cmd.rs
@@ -25,14 +25,14 @@ async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std
 
     // Write desired states to disk.
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_discover,
         ..
     } = StatesDesiredDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk in a new set of resources.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut fn_tracker_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut fn_tracker_output).await?;
     let CmdContext {
         resources: resources_from_read,
         ..
@@ -73,7 +73,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     let mut fn_tracker_output = FnTrackerOutput::new();
 
     // Try and display states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut fn_tracker_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut fn_tracker_output).await?;
     let exec_result = StatesDesiredDisplayCmd::exec(cmd_context).await;
 
     assert!(matches!(

--- a/workspace_tests/src/rt/states_desired_display_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_display_cmd.rs
@@ -10,12 +10,11 @@ use crate::{FnInvocation, FnTrackerOutput, NoOpOutput, VecCopyError, VecCopyItem
 #[tokio::test]
 async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -59,12 +58,11 @@ async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std
 #[tokio::test]
 async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_desired_display_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_display_cmd.rs
@@ -90,3 +90,14 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     );
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesDesiredDisplayCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesDesiredDisplayCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_desired_read_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_read_cmd.rs
@@ -73,3 +73,14 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     ));
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesDesiredReadCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesDesiredReadCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_desired_read_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_read_cmd.rs
@@ -10,12 +10,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());
@@ -50,12 +49,11 @@ async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std
 #[tokio::test]
 async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt/states_desired_read_cmd.rs
+++ b/workspace_tests/src/rt/states_desired_read_cmd.rs
@@ -24,14 +24,14 @@ async fn reads_states_desired_from_disk_when_present() -> Result<(), Box<dyn std
     let mut no_op_output = NoOpOutput;
 
     // Write desired states to disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_discover,
         ..
     } = StatesDesiredDiscoverCmd::exec(cmd_context).await?;
 
     // Re-read states from disk in a new set of resources.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let CmdContext {
         resources: resources_from_read,
         ..
@@ -64,7 +64,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
     let mut no_op_output = NoOpOutput;
 
     // Try and read desired states from disk.
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
     let exec_result = StatesDesiredReadCmd::exec(cmd_context).await;
 
     assert!(matches!(

--- a/workspace_tests/src/rt/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_discover_cmd.rs
@@ -72,3 +72,14 @@ async fn runs_state_current_and_state_desired() -> Result<(), Box<dyn std::error
 
     Ok(())
 }
+
+#[test]
+fn debug() {
+    assert_eq!(
+        "StatesDiscoverCmd(PhantomData)",
+        format!(
+            "{:?}",
+            StatesDiscoverCmd::<VecCopyError, NoOpOutput>::default()
+        )
+    );
+}

--- a/workspace_tests/src/rt/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_discover_cmd.rs
@@ -26,7 +26,7 @@ async fn runs_state_current_and_state_desired() -> Result<(), Box<dyn std::error
         graph_builder.build()
     };
     let mut no_op_output = NoOpOutput;
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let CmdContext { resources, .. } = StatesDiscoverCmd::exec(cmd_context).await?;
 

--- a/workspace_tests/src/rt/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/states_discover_cmd.rs
@@ -14,12 +14,11 @@ use crate::{NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn runs_state_current_and_state_desired() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().to_path_buf()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt_model.rs
+++ b/workspace_tests/src/rt_model.rs
@@ -1,6 +1,6 @@
 mod cli_output;
 mod cmd_context;
+mod cmd_context_builder;
 mod item_spec_boxed;
 mod item_spec_wrapper;
-mod workspace;
 mod workspace_dirs_builder;

--- a/workspace_tests/src/rt_model/cli_output.rs
+++ b/workspace_tests/src/rt_model/cli_output.rs
@@ -22,8 +22,7 @@ async fn outputs_states_current_verbose_mode() -> Result<(), Box<dyn std::error:
         .await?;
 
     assert_eq!(
-        r#"---
-item_0:
+        r#"item_0:
   logical: logical
   physical: 1.1
 item_1:
@@ -50,8 +49,7 @@ async fn outputs_states_desired_verbose_mode() -> Result<(), Box<dyn std::error:
         .await?;
 
     assert_eq!(
-        r#"---
-item_0:
+        r#"item_0:
   logical: logical
   physical: 1.1
 item_1:
@@ -77,8 +75,7 @@ async fn outputs_state_diffs_verbose_mode() -> Result<(), Box<dyn std::error::Er
     <CliOutput<_> as OutputWrite<Error>>::write_state_diffs(&mut cli_output, &state_diffs).await?;
 
     assert_eq!(
-        r#"---
-item_0: need one more server
+        r#"item_0: need one more server
 item_1: 1
 "#,
         String::from_utf8(buffer)?

--- a/workspace_tests/src/rt_model/cmd_context.rs
+++ b/workspace_tests/src/rt_model/cmd_context.rs
@@ -12,12 +12,11 @@ use crate::{NoOpOutput, VecA, VecB, VecCopyItemSpec};
 async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_working_dir()
 -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().into()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut builder = ItemSpecGraphBuilder::new();
         builder.add_fn(VecCopyItemSpec.into());
@@ -47,12 +46,11 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_working_d
 #[tokio::test]
 async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_path()
 -> Result<(), Box<dyn std::error::Error>> {
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(PathBuf::from(".")),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut builder = ItemSpecGraphBuilder::new();
         builder.add_fn(VecCopyItemSpec.into());
@@ -88,12 +86,11 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_first_dir
     tokio::fs::write(tempdir.path().join("Cargo.lock"), "").await?;
     tokio::fs::create_dir(&subdir).await?;
     std::env::set_current_dir(&subdir)?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::FirstDirWithFile("Cargo.lock".into()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut builder = ItemSpecGraphBuilder::new();
         builder.add_fn(VecCopyItemSpec.into());
@@ -123,12 +120,11 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_first_dir
 #[tokio::test]
 async fn init_runs_graph_setup() -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().into()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut builder = ItemSpecGraphBuilder::new();
         builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt_model/cmd_context.rs
+++ b/workspace_tests/src/rt_model/cmd_context.rs
@@ -25,7 +25,7 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_working_d
     };
     let mut no_op_output = NoOpOutput;
 
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let resources = cmd_context.resources();
     assert!(resources.try_borrow::<PeaceDir>().is_ok());
@@ -60,7 +60,7 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_path()
     };
     let mut no_op_output = NoOpOutput;
 
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let resources = cmd_context.resources();
     assert!(resources.try_borrow::<PeaceDir>().is_ok());
@@ -101,7 +101,7 @@ async fn init_inserts_workspace_dirs_into_resources_for_workspace_spec_first_dir
     };
     let mut no_op_output = NoOpOutput;
 
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let resources = cmd_context.resources();
     assert!(resources.try_borrow::<PeaceDir>().is_ok());
@@ -136,7 +136,7 @@ async fn init_runs_graph_setup() -> Result<(), Box<dyn std::error::Error>> {
     };
     let mut no_op_output = NoOpOutput;
 
-    let cmd_context = CmdContext::init(&workspace, &graph, &mut no_op_output).await?;
+    let cmd_context = CmdContext::builder(&workspace, &graph, &mut no_op_output).await?;
 
     let resources = cmd_context.resources();
     assert!(resources.try_borrow::<VecA>().is_ok());

--- a/workspace_tests/src/rt_model/cmd_context_builder.rs
+++ b/workspace_tests/src/rt_model/cmd_context_builder.rs
@@ -2,7 +2,11 @@ use std::path::Path;
 
 use peace::{
     cfg::{flow_id, profile, FlowId, Profile},
-    rt_model::{CmdContextBuilder, ItemSpecGraphBuilder, Workspace, WorkspaceSpec},
+    resources::internal::{FlowInitFile, ProfileInitFile, WorkspaceInitFile},
+    rt_model::{
+        CmdContext, CmdContextBuilder, ItemSpecGraph, ItemSpecGraphBuilder, Workspace,
+        WorkspaceSpec,
+    },
 };
 
 use crate::{no_op_output::NoOpOutput, VecCopyError, VecCopyItemSpec};
@@ -10,19 +14,9 @@ use crate::{no_op_output::NoOpOutput, VecCopyError, VecCopyItemSpec};
 #[tokio::test]
 async fn build_initializes_dirs_using_profile_and_physically_creates_dirs()
 -> Result<(), Box<dyn std::error::Error>> {
-    let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::new(
-        WorkspaceSpec::Path(tempdir.path().into()),
-        profile!("test_profile"),
-        flow_id!("test_flow"),
-    )?;
-    let graph = {
-        let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
-        graph_builder.add_fn(VecCopyItemSpec.into());
-        graph_builder.build()
-    };
-    let mut no_op_output = NoOpOutput;
-    CmdContextBuilder::new(&workspace, &graph, &mut no_op_output).await?;
+    let (tempdir, workspace, graph, mut output) = test_setup().await?;
+
+    CmdContextBuilder::new(&workspace, &graph, &mut output).await?;
 
     let workspace_dirs = workspace.dirs();
     let workspace_dir = tempdir.path();
@@ -49,4 +43,159 @@ async fn build_initializes_dirs_using_profile_and_physically_creates_dirs()
     .iter()
     .for_each(|dir| assert!(dir.exists()));
     Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_workspace_init_params_from_parameter()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_workspace_init(Some("workspace_init".to_string()))
+        .await?;
+    let workspace_init_file = resources.borrow::<WorkspaceInitFile>();
+    let workspace_init = resources.borrow::<String>();
+
+    assert!(workspace_init_file.exists());
+    assert_eq!(
+        "workspace_init\n",
+        tokio::fs::read_to_string(&*workspace_init_file).await?
+    );
+    assert_eq!("workspace_init", workspace_init.as_str());
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_workspace_init_params_from_storage() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+    let _cmd_context = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_workspace_init(Some("workspace_init".to_string()))
+        .await?;
+
+    // Create another CmdContext, this time using no parameter.
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_workspace_init::<String>(None)
+        .await?;
+    let workspace_init_file = resources.borrow::<WorkspaceInitFile>();
+    let workspace_init = resources.borrow::<String>();
+
+    assert!(workspace_init_file.exists());
+    assert_eq!(
+        "workspace_init\n",
+        tokio::fs::read_to_string(&*workspace_init_file).await?
+    );
+    assert_eq!("workspace_init", workspace_init.as_str());
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_profile_init_params_from_parameter() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_profile_init(Some("profile_init".to_string()))
+        .await?;
+    let profile_init_file = resources.borrow::<ProfileInitFile>();
+    let profile_init = resources.borrow::<String>();
+
+    assert!(profile_init_file.exists());
+    assert_eq!(
+        "profile_init\n",
+        tokio::fs::read_to_string(&*profile_init_file).await?
+    );
+    assert_eq!("profile_init", profile_init.as_str());
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_profile_init_params_from_storage() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+    let _cmd_context = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_profile_init(Some("profile_init".to_string()))
+        .await?;
+
+    // Create another CmdContext, this time using no parameter.
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_profile_init::<String>(None)
+        .await?;
+    let profile_init_file = resources.borrow::<ProfileInitFile>();
+    let profile_init = resources.borrow::<String>();
+
+    assert!(profile_init_file.exists());
+    assert_eq!(
+        "profile_init\n",
+        tokio::fs::read_to_string(&*profile_init_file).await?
+    );
+    assert_eq!("profile_init", profile_init.as_str());
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_flow_init_params_from_parameter() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_flow_init(Some("flow_init".to_string()))
+        .await?;
+    let flow_init_file = resources.borrow::<FlowInitFile>();
+    let flow_init = resources.borrow::<String>();
+
+    assert!(flow_init_file.exists());
+    assert_eq!(
+        "flow_init\n",
+        tokio::fs::read_to_string(&*flow_init_file).await?
+    );
+    assert_eq!("flow_init", flow_init.as_str());
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_inserts_flow_init_params_from_storage() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tempdir, workspace, graph, mut output) = test_setup().await?;
+    let _cmd_context = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_flow_init(Some("flow_init".to_string()))
+        .await?;
+
+    // Create another CmdContext, this time using no parameter.
+    let CmdContext { resources, .. } = CmdContextBuilder::new(&workspace, &graph, &mut output)
+        .with_flow_init::<String>(None)
+        .await?;
+    let flow_init_file = resources.borrow::<FlowInitFile>();
+    let flow_init = resources.borrow::<String>();
+
+    assert!(flow_init_file.exists());
+    assert_eq!(
+        "flow_init\n",
+        tokio::fs::read_to_string(&*flow_init_file).await?
+    );
+    assert_eq!("flow_init", flow_init.as_str());
+    Ok(())
+}
+
+// Test fixture
+async fn test_setup() -> Result<
+    (
+        tempfile::TempDir,
+        Workspace,
+        ItemSpecGraph<VecCopyError>,
+        NoOpOutput,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        WorkspaceSpec::Path(tempdir.path().into()),
+        profile!("test_profile"),
+        flow_id!("test_flow"),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
+        graph_builder.add_fn(VecCopyItemSpec.into());
+        graph_builder.build()
+    };
+
+    Ok((tempdir, workspace, graph, NoOpOutput))
 }

--- a/workspace_tests/src/rt_model/cmd_context_builder.rs
+++ b/workspace_tests/src/rt_model/cmd_context_builder.rs
@@ -11,12 +11,11 @@ use crate::{no_op_output::NoOpOutput, VecCopyError, VecCopyItemSpec};
 async fn build_initializes_dirs_using_profile_and_physically_creates_dirs()
 -> Result<(), Box<dyn std::error::Error>> {
     let tempdir = tempfile::tempdir()?;
-    let workspace = Workspace::init(
+    let workspace = Workspace::new(
         WorkspaceSpec::Path(tempdir.path().into()),
         profile!("test_profile"),
         flow_id!("test_flow"),
-    )
-    .await?;
+    )?;
     let graph = {
         let mut graph_builder = ItemSpecGraphBuilder::<VecCopyError>::new();
         graph_builder.add_fn(VecCopyItemSpec.into());

--- a/workspace_tests/src/rt_model/item_spec_boxed.rs
+++ b/workspace_tests/src/rt_model/item_spec_boxed.rs
@@ -1,6 +1,11 @@
-use peace::rt_model::{ItemSpecBoxed, ItemSpecRt};
+use std::any::TypeId;
 
-use crate::{VecCopyError, VecCopyItemSpec};
+use peace::{
+    data::{DataAccessDyn, TypeIds},
+    rt_model::{ItemSpecBoxed, ItemSpecRt},
+};
+
+use crate::{vec_copy_item_spec::VecB, VecCopyError, VecCopyItemSpec};
 
 #[test]
 fn deref_to_dyn_item_spec_rt() {
@@ -15,11 +20,46 @@ fn deref_to_dyn_item_spec_rt() {
 
 #[test]
 fn deref_mut_to_dyn_item_spec_rt() {
-    let item_spec_boxed: ItemSpecBoxed<VecCopyError> = VecCopyItemSpec.into();
-    let item_spec_rt: &dyn ItemSpecRt<_> = &*item_spec_boxed;
+    let mut item_spec_boxed: ItemSpecBoxed<VecCopyError> = VecCopyItemSpec.into();
+    let item_spec_rt: &mut dyn ItemSpecRt<_> = &mut *item_spec_boxed;
 
     assert_eq!(
         format!("{:?}", VecCopyItemSpec),
         format!("{:?}", item_spec_rt)
+    );
+}
+
+#[test]
+fn data_access_dyn_borrows() {
+    let type_ids = TypeIds::new();
+
+    let item_spec_boxed: ItemSpecBoxed<VecCopyError> = VecCopyItemSpec.into();
+
+    assert_eq!(
+        type_ids,
+        <ItemSpecBoxed<VecCopyError> as DataAccessDyn>::borrows(&item_spec_boxed)
+    );
+}
+
+#[test]
+fn data_access_dyn_borrow_muts() {
+    let mut type_ids = TypeIds::new();
+    type_ids.push(TypeId::of::<VecB>());
+
+    let item_spec_boxed: ItemSpecBoxed<VecCopyError> = VecCopyItemSpec.into();
+
+    assert_eq!(
+        type_ids,
+        <ItemSpecBoxed<VecCopyError> as DataAccessDyn>::borrow_muts(&item_spec_boxed)
+    );
+}
+
+#[test]
+fn debug() {
+    let item_spec_boxed: ItemSpecBoxed<VecCopyError> = VecCopyItemSpec.into();
+
+    assert_eq!(
+        "ItemSpecBoxed(VecCopyItemSpec)",
+        format!("{:?}", item_spec_boxed)
     );
 }


### PR DESCRIPTION
This allows parameters to persist between separate command invocations / requests by storing them inside the `.peace` directory.

```bash
.peace
  |- init.yaml # workspace parameters
  |
  |- my_ip_address # profile
      |- init.yaml # profile parameters
      |
      |- download # flow
          |- init.yaml # flow parameters
```

Closes #29.