### PR TITLE
Lock mdbook-graphviz to 0.1.4.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.mdbook_graphviz_cache.outputs.cache-hit != 'true'
         with:
           command: install
-          args: mdbook-graphviz
+          args: mdbook-graphviz --version 0.1.4
 
       - name: 'Build examples'
         run: |


### PR DESCRIPTION
Attempt to fix the [User Facing Automation - Part 1](https://peace.mk/learning_material/user_facing_automation_part_1.html) page where `dot` doesn't appear to be run, but it is run for the other Concept pages.