### PR TITLE
Remove incorrect documentation

### DIFF
--- a/crate/rt_model_native/src/workspace.rs
+++ b/crate/rt_model_native/src/workspace.rs
@@ -41,8 +41,6 @@ impl Workspace {
     ///
     /// * `app_name`: Name of the final application.
     /// * `workspace_spec`: Defines how to discover the workspace.
-    /// * `profile`: The profile / namespace that the execution is flow.
-    /// * `flow_id`: ID of the flow that is being executed.
     pub fn new(app_name: AppName, workspace_spec: WorkspaceSpec) -> Result<Self, Error> {
         let dirs = WorkspaceDirsBuilder::build(&app_name, workspace_spec)?;
         let storage = Storage;


### PR DESCRIPTION
This PR removes the old documentation of workspace init method as the parameters of the function has changed.