### PR TITLE
Include entry for current and discovered states, and diff in `app_cycle` example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Display messages in CLI progress bars. ([#102], [#103])
 * Display progress bars during state discovery. ([#100], [#104])
 * Clear progress bars on command end. ([#100], [#104])
+* Include entry for current and discovered states, and diff in `app_cycle` example. ([#91], [#105])
+* Sort progress bars based on insertion order. ([#91], [#105])
+* Use `▰` and `▱` parallelogram characters for progress bars. ([#91], [#105])
+* Spinner progress is now rendered. ([#91], [#105])
 
 [#94]: https://github.com/azriel91/peace/issues/94
 [#95]: https://github.com/azriel91/peace/pull/95
@@ -20,6 +24,8 @@
 [#103]: https://github.com/azriel91/peace/pull/103
 [#100]: https://github.com/azriel91/peace/issues/100
 [#104]: https://github.com/azriel91/peace/pull/104
+[#91]: https://github.com/azriel91/peace/issues/91
+[#105]: https://github.com/azriel91/peace/pull/105
 
 
 ## 0.0.7 (2023-03-06)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 cfg-if = "1.0.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"] }
 derivative = "2.2.0"
+indexmap = "1.9.2"
 indicatif = { version = "0.17.3" }
 miette = { version = "5.5.0" }
 tar = "0.4.38"

--- a/crate/code_gen/src/cmd/impl_build.rs
+++ b/crate/code_gen/src/cmd/impl_build.rs
@@ -547,7 +547,7 @@ fn impl_build_for(
                 //         indicatif::ProgressDrawTarget::hidden()
                 //     );
                 //     let progress_trackers = item_spec_graph.iter_insertion().fold(
-                //         std::collections::HashMap::with_capacity(item_spec_graph.node_count()),
+                //         peace_rt_model::IndexMap::with_capacity(item_spec_graph.node_count()),
                 //         |mut progress_trackers, item_spec| {
                 //             let progress_bar = multi_progress.add(indicatif::ProgressBar::hidden());
                 //             let progress_tracker = indicatif::style::ProgressTracker::new(progress_bar);
@@ -1433,7 +1433,7 @@ fn states_saved_read_and_pg_init(scope: Scope) -> proc_macro2::TokenStream {
                         indicatif::ProgressDrawTarget::hidden()
                     );
                     let progress_trackers = item_spec_graph.iter_insertion().fold(
-                        std::collections::HashMap::with_capacity(item_spec_graph.node_count()),
+                        peace_rt_model::IndexMap::with_capacity(item_spec_graph.node_count()),
                         |mut progress_trackers, item_spec| {
                             let progress_bar = multi_progress.add(indicatif::ProgressBar::hidden());
                             let progress_tracker = peace_core::progress::ProgressTracker::new(progress_bar);

--- a/crate/fmt/src/presentable.rs
+++ b/crate/fmt/src/presentable.rs
@@ -1,5 +1,6 @@
 pub use self::{
     bold::Bold, code_inline::CodeInline, heading::Heading, heading_level::HeadingLevel,
+    list_numbered::ListNumbered,
 };
 
 use serde::Serialize;
@@ -10,13 +11,15 @@ mod bold;
 mod code_inline;
 mod heading;
 mod heading_level;
+mod list_numbered;
 mod tuple_impl;
 
 /// A type that is presentable to a user.
 ///
-/// This is analogous to `std::fmt::Display`, with the difference that instead
-/// of formatting an unstyled string, implementations register how they are
-/// presented with a [`Presenter`].
+/// This is analogous in concept to `std::fmt::Display`, and in implementation
+/// to `std::fmt::Debug`, with the difference that instead of formatting an
+/// unstyled string, implementations register how they are presented with a
+/// [`Presenter`].
 ///
 /// # Implementors
 ///
@@ -69,6 +72,12 @@ mod tuple_impl;
 /// ```
 ///
 /// # Design
+///
+/// `Presentable` implies `Serialize` because it is beneficial for anything that
+/// is presented to the user, to be able to be stored, so that it can be
+/// re-presented to them at a later time. However, it currently doesn't imply
+/// `DeserializeOwned`, which may mean the serialization half may not be
+/// worthwhile, and `Presentable` wrapper types may just wrap borrowed data.
 ///
 /// Previously, this was implemented as `Presentable: Serialize +
 /// OwnedDeserialize`, with `OwnedDeserialize` being the following trait:

--- a/crate/fmt/src/presentable.rs
+++ b/crate/fmt/src/presentable.rs
@@ -1,10 +1,15 @@
-pub use self::code_inline::CodeInline;
+pub use self::{
+    bold::Bold, code_inline::CodeInline, heading::Heading, heading_level::HeadingLevel,
+};
 
 use serde::Serialize;
 
 use crate::Presenter;
 
+mod bold;
 mod code_inline;
+mod heading;
+mod heading_level;
 mod tuple_impl;
 
 /// A type that is presentable to a user.
@@ -112,7 +117,7 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl Presentable for str {
+impl Presentable for &str {
     async fn present<'output, PR>(&self, presenter: &mut PR) -> Result<(), PR::Error>
     where
         PR: Presenter<'output>,

--- a/crate/fmt/src/presentable/bold.rs
+++ b/crate/fmt/src/presentable/bold.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Presentable, Presenter};
+
+/// Presents the given presentable as bolded.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Bold<P>(P);
+
+impl<P> Bold<P> {
+    /// Returns a new `Bold` wrapper.
+    pub fn new(presentable: P) -> Self {
+        Self(presentable)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<P> Presentable for Bold<P>
+where
+    P: Presentable,
+{
+    async fn present<'output, PR>(&self, presenter: &mut PR) -> Result<(), PR::Error>
+    where
+        PR: Presenter<'output>,
+    {
+        presenter.bold(&self.0).await
+    }
+}

--- a/crate/fmt/src/presentable/heading.rs
+++ b/crate/fmt/src/presentable/heading.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{presentable::HeadingLevel, Presentable, Presenter};
+
+/// Presents the given string as a heading.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Heading<P> {
+    /// Level of conceptual detail for a given topic.
+    level: HeadingLevel,
+    /// The heading level.
+    presentable: P,
+}
+
+impl<P> Heading<P> {
+    /// Returns a new `Heading` wrapper.
+    pub fn new(level: HeadingLevel, presentable: P) -> Self {
+        Self { level, presentable }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<P> Presentable for Heading<P>
+where
+    P: Presentable,
+{
+    async fn present<'output, PR>(&self, presenter: &mut PR) -> Result<(), PR::Error>
+    where
+        PR: Presenter<'output>,
+    {
+        presenter.heading(self.level, &self.presentable).await
+    }
+}

--- a/crate/fmt/src/presentable/heading_level.rs
+++ b/crate/fmt/src/presentable/heading_level.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+/// Level of conceptual detail for a given topic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum HeadingLevel {
+    /// Top level heading.
+    Level1,
+    /// Second level heading.
+    Level2,
+    /// Third level heading.
+    Level3,
+    /// Fourth level heading.
+    Level4,
+    /// Fifth level heading.
+    Level5,
+    /// Lowest level of conceptual detail.
+    Level6,
+}

--- a/crate/fmt/src/presentable/list_numbered.rs
+++ b/crate/fmt/src/presentable/list_numbered.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Presentable, Presenter};
+
+/// Presents the given iterator as a numbered list.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ListNumbered<P>(Vec<P>);
+
+impl<P> ListNumbered<P> {
+    /// Returns a new `ListNumbered` wrapper.
+    pub fn new(presentables: Vec<P>) -> Self {
+        Self(presentables)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<P> Presentable for ListNumbered<P>
+where
+    P: Presentable,
+{
+    async fn present<'output, PR>(&self, presenter: &mut PR) -> Result<(), PR::Error>
+    where
+        PR: Presenter<'output>,
+    {
+        presenter.list_numbered(&self.0).await
+    }
+}

--- a/crate/fmt/src/presentable/tuple_impl.rs
+++ b/crate/fmt/src/presentable/tuple_impl.rs
@@ -32,18 +32,6 @@ macro_rules! tuple_presentable_impl {
     };
 }
 
-// Generated using the following script on ZSH:
-//
-// ```bash
-// for i in {1..15}; do
-//     printf 'tuple_presentable_impl!((T0'
-//     for j in {1..$i}; do printf ', T%d' $j; done
-//     printf '), [0'
-//     for j in {1..$i}; do printf ', %d' $j; done
-//     printf ']);\n'
-// done
-// ```
-
 tuple_presentable_impl!((T0, T1), [0, 1]);
 tuple_presentable_impl!((T0, T1, T2), [0, 1, 2]);
 tuple_presentable_impl!((T0, T1, T2, T3), [0, 1, 2, 3]);

--- a/crate/fmt/src/presenter.rs
+++ b/crate/fmt/src/presenter.rs
@@ -1,4 +1,4 @@
-use crate::Presentable;
+use crate::{presentable::HeadingLevel, Presentable};
 
 /// Takes a `Presentable` type and presents it to the user.
 ///
@@ -38,6 +38,15 @@ use crate::Presentable;
 /// held in memory for each entry.
 #[async_trait::async_trait(?Send)]
 pub trait Presenter<'output> {
+    /// Presents the given presentable as a heading.
+    ///
+    /// # Purposes
+    ///
+    /// * Headings.
+    async fn heading<P>(&mut self, level: HeadingLevel, presentable: &P) -> Result<(), Self::Error>
+    where
+        P: Presentable + ?Sized;
+
     /// Error returned during a presentation failure.
     type Error: std::error::Error;
 
@@ -57,6 +66,15 @@ pub trait Presenter<'output> {
 
     /// Presents text as plain text.
     async fn text(&mut self, text: &str) -> Result<(), Self::Error>;
+
+    /// Presents the given presentable bolded.
+    ///
+    /// # Purposes
+    ///
+    /// * Emphasis.
+    async fn bold<P>(&mut self, presentable: &P) -> Result<(), Self::Error>
+    where
+        P: Presentable + ?Sized;
 
     /// Presents text as inline code.
     ///

--- a/crate/rt/src/cmds/sub/apply_cmd.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd.rs
@@ -364,6 +364,16 @@ where
                             msg_update: ProgressMsgUpdate::Set(String::from("nothing to do!")),
                         });
 
+                        // TODO: write test for this case
+                        // In case of an interrupt or power failure, we may not have written states
+                        // to disk.
+                        outcomes_tx
+                            .send(ItemApplyOutcome::Success {
+                                item_spec_id: item_spec.id().clone(),
+                                item_apply,
+                            })
+                            .expect("unreachable: `outcomes_rx` is in a sibling task.");
+
                         // short-circuit
                         return Ok(());
                     }

--- a/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_current_discover_cmd.rs
@@ -15,8 +15,6 @@ use peace_resources::{
 };
 use peace_rt_model::{output::OutputWrite, params::ParamsKeys, Error, Storage};
 
-use crate::BUFFERED_FUTURES_MAX;
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {
         use peace_cfg::{
@@ -124,14 +122,8 @@ where
 
                     let state = state?;
 
-                    Ok(state
-                        .map(|state| (item_spec.id().clone(), state))
-                        .map(Result::Ok)
-                        .map(futures::future::ready))
+                    Ok(state.map(|state| (item_spec.id().clone(), state)))
                 })
-                // TODO: do we need this?
-                // If not, we can remove the `Ok` and `future::ready` mappings above.
-                .try_buffer_unordered(BUFFERED_FUTURES_MAX)
                 .try_collect::<StatesMut<Current>>()
                 .await?;
 

--- a/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
+++ b/crate/rt/src/cmds/sub/states_desired_discover_cmd.rs
@@ -15,8 +15,6 @@ use peace_resources::{
 };
 use peace_rt_model::{output::OutputWrite, params::ParamsKeys, Error, Storage};
 
-use crate::BUFFERED_FUTURES_MAX;
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {
         use peace_cfg::{
@@ -124,14 +122,8 @@ where
 
                     let state = state?;
 
-                    Ok(state
-                        .map(|state| (item_spec.id().clone(), state))
-                        .map(Result::Ok)
-                        .map(futures::future::ready))
+                    Ok(state.map(|state| (item_spec.id().clone(), state)))
                 })
-                // TODO: do we need this?
-                // If not, we can remove the `Ok` and `future::ready` mappings above.
-                .try_buffer_unordered(BUFFERED_FUTURES_MAX)
                 .try_collect::<StatesMut<Desired>>()
                 .await?;
 

--- a/crate/rt/src/progress.rs
+++ b/crate/rt/src/progress.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use peace_cfg::{
     progress::{
         ProgressDelta, ProgressMsgUpdate, ProgressStatus, ProgressTracker, ProgressUpdate,
@@ -7,7 +5,7 @@ use peace_cfg::{
     },
     ItemSpecId,
 };
-use peace_rt_model::output::OutputWrite;
+use peace_rt_model::{output::OutputWrite, IndexMap};
 use tokio::sync::mpsc::Receiver;
 
 pub struct Progress;
@@ -16,7 +14,7 @@ impl Progress {
     /// Receives progress updates and updates `output` to render it.
     pub async fn progress_render<E, O>(
         output: &mut O,
-        progress_trackers: &mut HashMap<ItemSpecId, ProgressTracker>,
+        progress_trackers: &mut IndexMap<ItemSpecId, ProgressTracker>,
         mut progress_rx: Receiver<ProgressUpdateAndId>,
     ) where
         O: OutputWrite<E>,
@@ -33,6 +31,7 @@ impl Progress {
             };
             match progress_update {
                 ProgressUpdate::Reset => {
+                    progress_tracker.set_progress_status(ProgressStatus::Initialized);
                     let progress_bar = progress_tracker.progress_bar();
                     progress_bar.reset();
                 }

--- a/crate/rt_model/src/in_memory_text_output.rs
+++ b/crate/rt_model/src/in_memory_text_output.rs
@@ -54,11 +54,11 @@ where
     #[cfg(feature = "output_progress")]
     async fn progress_end(&mut self, _cmd_progress_tracker: &CmdProgressTracker) {}
 
-    async fn present<P>(&mut self, presentable: &P) -> Result<(), E>
+    async fn present<P>(&mut self, presentable: P) -> Result<(), E>
     where
-        P: Presentable + ?Sized,
+        P: Presentable,
     {
-        self.buffer = serde_yaml::to_string(presentable).map_err(Error::StatesSerialize)?;
+        self.buffer = serde_yaml::to_string(&presentable).map_err(Error::StatesSerialize)?;
 
         Ok(())
     }

--- a/crate/rt_model_core/Cargo.toml
+++ b/crate/rt_model_core/Cargo.toml
@@ -19,6 +19,7 @@ test = false
 async-trait = "0.1.66"
 cfg-if = { workspace = true }
 indicatif = { workspace = true, features = ["tokio"] }
+indexmap = { workspace = true }
 miette = { workspace = true, optional = true }
 peace_core = { path = "../core", version = "0.0.7" }
 peace_fmt = { path = "../fmt", version = "0.0.7" }

--- a/crate/rt_model_core/src/cmd_progress_tracker.rs
+++ b/crate/rt_model_core/src/cmd_progress_tracker.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use indicatif::MultiProgress;
 use peace_core::{progress::ProgressTracker, ItemSpecId};
 
@@ -19,14 +18,14 @@ pub struct CmdProgressTracker {
     /// `MultiProgress` that tracks the remaining progress bars.
     pub multi_progress: MultiProgress,
     /// Tracks progress for each item spec.
-    pub progress_trackers: HashMap<ItemSpecId, ProgressTracker>,
+    pub progress_trackers: IndexMap<ItemSpecId, ProgressTracker>,
 }
 
 impl CmdProgressTracker {
     /// Returns a new `CmdProgressTracker`.
     pub fn new(
         multi_progress: MultiProgress,
-        progress_trackers: HashMap<ItemSpecId, ProgressTracker>,
+        progress_trackers: IndexMap<ItemSpecId, ProgressTracker>,
     ) -> Self {
         Self {
             multi_progress,
@@ -46,13 +45,13 @@ impl CmdProgressTracker {
     }
 
     /// Returns the `ProgressTracker`s for each item spec.
-    pub fn progress_trackers(&self) -> &HashMap<ItemSpecId, ProgressTracker> {
+    pub fn progress_trackers(&self) -> &IndexMap<ItemSpecId, ProgressTracker> {
         &self.progress_trackers
     }
 
     /// Returns a mutable reference to the `ProgressTracker`s for each item
     /// spec.
-    pub fn progress_trackers_mut(&mut self) -> &mut HashMap<ItemSpecId, ProgressTracker> {
+    pub fn progress_trackers_mut(&mut self) -> &mut IndexMap<ItemSpecId, ProgressTracker> {
         &mut self.progress_trackers
     }
 }

--- a/crate/rt_model_core/src/lib.rs
+++ b/crate/rt_model_core/src/lib.rs
@@ -6,6 +6,7 @@
 
 // Re-exports
 pub use async_trait::async_trait;
+pub use indexmap::IndexMap;
 pub use indicatif;
 
 pub mod output;

--- a/crate/rt_model_core/src/output/output_write.rs
+++ b/crate/rt_model_core/src/output/output_write.rs
@@ -66,10 +66,10 @@ pub trait OutputWrite<E> {
     async fn progress_end(&mut self, cmd_progress_tracker: &CmdProgressTracker);
 
     /// Writes presentable information to the output.
-    async fn present<P>(&mut self, presentable: &P) -> Result<(), E>
+    async fn present<P>(&mut self, presentable: P) -> Result<(), E>
     where
         E: std::error::Error,
-        P: Presentable + ?Sized;
+        P: Presentable;
 
     /// Writes an error to the output.
     async fn write_err(&mut self, error: &E) -> Result<(), E>

--- a/crate/rt_model_native/src/output/cli_output.rs
+++ b/crate/rt_model_native/src/output/cli_output.rs
@@ -227,7 +227,7 @@ where
                         "`ProgressStyle` template was invalid. Template: `{template:?}`. Error: {error}"
                     )
                 })
-                .progress_chars("█▉▊▋▌▍▎▏  ")
+                .progress_chars("▰▱")
                 .tick_strings(&[
                     "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
                     "▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
@@ -288,8 +288,9 @@ where
     fn progress_bar_template(&self, progress_tracker: &ProgressTracker) -> String {
         /// This is used when we are rendering a bar that is not calculated by
         /// `ProgressBar`'s length and current value,
-        const SOLID_SPINNER: &str = " ▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ ";
-        const SOLID_BAR: &str = "▕▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▏";
+        const SOLID_BAR: &str = "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱";
+        #[cfg(feature = "output_colorized")]
+        const SOLID_SPINNER: &str = "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱";
 
         let icon = match progress_tracker.progress_status() {
             ProgressStatus::Initialized | ProgressStatus::ExecPending | ProgressStatus::Running => {
@@ -326,41 +327,31 @@ where
                             match progress_tracker.progress_status() {
                                 ProgressStatus::Initialized => console::style(SOLID_BAR).color256(GRAY_DARK),
                                 ProgressStatus::ExecPending | ProgressStatus::Running => {
-                                    console::style("▕{bar:40.32.on_17}▏")
+                                    console::style("{bar:40.32}")
                                 }
-                                ProgressStatus::RunningStalled => console::style("▕{bar:40.222.on_17}▏"),
-                                ProgressStatus::UserPending => console::style("▕{bar:40.75.on_17}▏"),
+                                ProgressStatus::RunningStalled => console::style("{bar:40.222}"),
+                                ProgressStatus::UserPending => console::style("{bar:40.75}"),
                                 ProgressStatus::Complete(progress_complete) => match progress_complete {
                                     ProgressComplete::Success => {
-                                        // for ProgressLimit::Unknown, only the background color shows, so we need to make it bright green.
-                                        if matches!(progress_tracker.progress_limit(), Some(ProgressLimit::Unknown)) {
-                                            console::style("▕{bar:40.35.on_35}▏")
-                                        } else {
-                                            console::style("▕{bar:40.35.on_22}▏")
-                                        }
+                                        console::style("{bar:40.35}")
                                     },
-                                    ProgressComplete::Fail => console::style("▕{bar:40.160.on_88}▏"),
+                                    ProgressComplete::Fail => console::style("{bar:40.160}"),
                                 },
                             }
                         } else {
-
+                            // No progress limit (as opposed to unknown)
                             match progress_tracker.progress_status() {
                                 ProgressStatus::Initialized => console::style(SOLID_SPINNER).color256(GRAY_MED),
                                 ProgressStatus::ExecPending | ProgressStatus::Running => {
-                                    console::style(" {spinner:40.32} ")
+                                    console::style("{spinner:40.32}")
                                 }
-                                ProgressStatus::RunningStalled => console::style(" {spinner:40.222} "),
-                                ProgressStatus::UserPending => console::style(" {spinner:40.75} "),
+                                ProgressStatus::RunningStalled => console::style("{spinner:40.222}"),
+                                ProgressStatus::UserPending => console::style("{spinner:40.75}"),
                                 ProgressStatus::Complete(progress_complete) => match progress_complete {
                                     ProgressComplete::Success => {
-                                        // for ProgressLimit::Unknown, only the background color shows, so we need to make it bright green.
-                                        if matches!(progress_tracker.progress_limit(), Some(ProgressLimit::Unknown)) {
-                                            console::style(" {spinner:40.35} ")
-                                        } else {
-                                            console::style(" {spinner:40.35} ")
-                                        }
+                                        console::style("{spinner:40.35}")
                                     },
-                                    ProgressComplete::Fail => console::style(" {spinner:40.160} "),
+                                    ProgressComplete::Fail => console::style("{spinner:40.160}"),
                                 },
                             }
                         }
@@ -372,10 +363,10 @@ where
                                 ProgressStatus::ExecPending | ProgressStatus::Running |
                                 ProgressStatus::RunningStalled |
                                 ProgressStatus::UserPending |
-                                ProgressStatus::Complete(_) => console::style("▕{bar:40}▏"),
+                                ProgressStatus::Complete(_) => console::style("{bar:40}"),
                             }
                         } else {
-                            console::style(" {spinner:40} ")
+                            console::style("{spinner:40}")
                         }
                     },
                 };
@@ -386,10 +377,10 @@ where
                         ProgressStatus::ExecPending | ProgressStatus::Running |
                         ProgressStatus::RunningStalled |
                         ProgressStatus::UserPending |
-                        ProgressStatus::Complete(_) => console::style("▕{bar:40}▏"),
+                        ProgressStatus::Complete(_) => console::style("{bar:40}"),
                     }
                 } else {
-                    console::style(" {spinner:40} ")
+                    console::style("{spinner:40}")
                 };
             }
         }

--- a/crate/rt_model_native/src/output/cli_output.rs
+++ b/crate/rt_model_native/src/output/cli_output.rs
@@ -160,10 +160,10 @@ where
         self.progress_format
     }
 
-    async fn output_presentable<E, P>(&mut self, presentable: &P) -> Result<(), E>
+    async fn output_presentable<E, P>(&mut self, presentable: P) -> Result<(), E>
     where
         E: std::error::Error + From<Error>,
-        P: Presentable + ?Sized,
+        P: Presentable,
     {
         let presenter = &mut CliMdPresenter::new(self);
         presentable
@@ -505,16 +505,16 @@ where
         let _result = cmd_progress_tracker.multi_progress.clear();
     }
 
-    async fn present<P>(&mut self, presentable: &P) -> Result<(), E>
+    async fn present<P>(&mut self, presentable: P) -> Result<(), E>
     where
-        P: Presentable + ?Sized,
+        P: Presentable,
     {
         match self.outcome_format {
             OutputFormat::Text => self.output_presentable(presentable).await,
-            OutputFormat::Yaml => self.output_yaml(presentable, Error::StatesSerialize).await,
+            OutputFormat::Yaml => self.output_yaml(&presentable, Error::StatesSerialize).await,
             #[cfg(feature = "output_json")]
             OutputFormat::Json => {
-                self.output_json(presentable, Error::StatesSerializeJson)
+                self.output_json(&presentable, Error::StatesSerializeJson)
                     .await
             }
         }

--- a/crate/rt_model_native/src/output/cli_output.rs
+++ b/crate/rt_model_native/src/output/cli_output.rs
@@ -227,7 +227,57 @@ where
                         "`ProgressStyle` template was invalid. Template: `{template:?}`. Error: {error}"
                     )
                 })
-                .progress_chars("█▉▊▋▌▍▎▏  "),
+                .progress_chars("█▉▊▋▌▍▎▏  ")
+                .tick_strings(&[
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰▱",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰",
+                    "▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰",
+                    "▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰",
+                ]),
         );
 
         // Rerender the progress bar after setting style.
@@ -238,7 +288,8 @@ where
     fn progress_bar_template(&self, progress_tracker: &ProgressTracker) -> String {
         /// This is used when we are rendering a bar that is not calculated by
         /// `ProgressBar`'s length and current value,
-        const SOLID_BAR: &str = "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒";
+        const SOLID_SPINNER: &str = " ▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ ";
+        const SOLID_BAR: &str = "▕▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▏";
 
         let icon = match progress_tracker.progress_status() {
             ProgressStatus::Initialized | ProgressStatus::ExecPending | ProgressStatus::Running => {
@@ -265,57 +316,84 @@ where
                 // 160: red slightly dim (fail)
                 //  88: red dark (fail background)
 
+                const GRAY_MED: u8 = 8;
                 const GRAY_DARK: u8 = 237;
                 const PURPLE: u8 = 128;
 
-                let bar = match self.colorize {
+                let bar_or_spinner = match self.colorize {
                     CliColorize::Colored => {
-                        match progress_tracker.progress_status() {
-                            ProgressStatus::Initialized => console::style(SOLID_BAR).color256(GRAY_DARK),
-                            ProgressStatus::ExecPending | ProgressStatus::Running => {
-                                console::style("{bar:40.32.on_17}")
-                            }
-                            ProgressStatus::RunningStalled => console::style("{bar:40.222.on_17}"),
-                            ProgressStatus::UserPending => console::style("{bar:40.75.on_17}"),
-                            ProgressStatus::Complete(progress_complete) => match progress_complete {
-                                ProgressComplete::Success => {
-                                    // for ProgressLimit::Unknown, only the background color shows, so we need to make it bright green.
-                                    if matches!(progress_tracker.progress_limit(), Some(ProgressLimit::Unknown)) {
-                                        console::style("{bar:40.35.on_35}")
-                                    } else {
-                                        console::style("{bar:40.35.on_22}")
-                                    }
+                        if progress_tracker.progress_limit().is_some() {
+                            match progress_tracker.progress_status() {
+                                ProgressStatus::Initialized => console::style(SOLID_BAR).color256(GRAY_DARK),
+                                ProgressStatus::ExecPending | ProgressStatus::Running => {
+                                    console::style("▕{bar:40.32.on_17}▏")
+                                }
+                                ProgressStatus::RunningStalled => console::style("▕{bar:40.222.on_17}▏"),
+                                ProgressStatus::UserPending => console::style("▕{bar:40.75.on_17}▏"),
+                                ProgressStatus::Complete(progress_complete) => match progress_complete {
+                                    ProgressComplete::Success => {
+                                        // for ProgressLimit::Unknown, only the background color shows, so we need to make it bright green.
+                                        if matches!(progress_tracker.progress_limit(), Some(ProgressLimit::Unknown)) {
+                                            console::style("▕{bar:40.35.on_35}▏")
+                                        } else {
+                                            console::style("▕{bar:40.35.on_22}▏")
+                                        }
+                                    },
+                                    ProgressComplete::Fail => console::style("▕{bar:40.160.on_88}▏"),
                                 },
-                                ProgressComplete::Fail => console::style("{bar:40.160.on_88}"),
-                            },
+                            }
+                        } else {
+
+                            match progress_tracker.progress_status() {
+                                ProgressStatus::Initialized => console::style(SOLID_SPINNER).color256(GRAY_MED),
+                                ProgressStatus::ExecPending | ProgressStatus::Running => {
+                                    console::style(" {spinner:40.32} ")
+                                }
+                                ProgressStatus::RunningStalled => console::style(" {spinner:40.222} "),
+                                ProgressStatus::UserPending => console::style(" {spinner:40.75} "),
+                                ProgressStatus::Complete(progress_complete) => match progress_complete {
+                                    ProgressComplete::Success => {
+                                        // for ProgressLimit::Unknown, only the background color shows, so we need to make it bright green.
+                                        if matches!(progress_tracker.progress_limit(), Some(ProgressLimit::Unknown)) {
+                                            console::style(" {spinner:40.35} ")
+                                        } else {
+                                            console::style(" {spinner:40.35} ")
+                                        }
+                                    },
+                                    ProgressComplete::Fail => console::style(" {spinner:40.160} "),
+                                },
+                            }
                         }
                     }
                     CliColorize::Uncolored => {
-                        match progress_tracker.progress_status() {
-                            ProgressStatus::Initialized => console::style(SOLID_BAR),
-                            ProgressStatus::ExecPending | ProgressStatus::Running |
-                            ProgressStatus::RunningStalled |
-                            ProgressStatus::UserPending |
-                            ProgressStatus::Complete(_) => console::style("{bar:40}"),
+                        if progress_tracker.progress_limit().is_some() {
+                            match progress_tracker.progress_status() {
+                                ProgressStatus::Initialized => console::style(SOLID_BAR),
+                                ProgressStatus::ExecPending | ProgressStatus::Running |
+                                ProgressStatus::RunningStalled |
+                                ProgressStatus::UserPending |
+                                ProgressStatus::Complete(_) => console::style("▕{bar:40}▏"),
+                            }
+                        } else {
+                            console::style(" {spinner:40} ")
                         }
                     },
                 };
-
-                let prefix = match self.colorize {
-                    CliColorize::Colored => "{prefix:20.75}",
-                    CliColorize::Uncolored => "{prefix:20}",
-                };
             } else {
-                let bar = match progress_tracker.progress_status() {
-                    ProgressStatus::Initialized => console::style(SOLID_BAR),
-                    ProgressStatus::ExecPending | ProgressStatus::Running |
-                    ProgressStatus::RunningStalled |
-                    ProgressStatus::UserPending |
-                    ProgressStatus::Complete(_) => console::style("{bar:40}"),
+                let bar_or_spinner = if progress_tracker.progress_limit().is_some() {
+                    match progress_tracker.progress_status() {
+                        ProgressStatus::Initialized => console::style(SOLID_BAR),
+                        ProgressStatus::ExecPending | ProgressStatus::Running |
+                        ProgressStatus::RunningStalled |
+                        ProgressStatus::UserPending |
+                        ProgressStatus::Complete(_) => console::style("▕{bar:40}▏"),
+                    }
+                } else {
+                    console::style(" {spinner:40} ")
                 };
-                let prefix = "{prefix:20}";
             }
         }
+        let prefix = "{prefix:20}";
 
         let progress_is_complete = matches!(
             progress_tracker.progress_status(),
@@ -349,7 +427,7 @@ where
         };
 
         // `prefix` is the item spec ID.
-        let mut format_str = format!("{icon} {prefix} ▕{bar}▏");
+        let mut format_str = format!("{icon} {prefix} {bar_or_spinner}");
         if let Some(units) = units {
             format_str.push_str(units);
         }
@@ -394,19 +472,53 @@ where
             .multi_progress()
             .set_draw_target(progress_draw_target);
 
+        // avoid reborrowing `self` within `for_each`
+        #[cfg(feature = "output_colorized")]
+        let colorize = self.colorize;
+
         match self.progress_format {
             CliProgressFormat::ProgressBar => {
-                cmd_progress_tracker.progress_trackers().iter().for_each(
-                    |(item_spec_id, progress_tracker)| {
+                cmd_progress_tracker
+                    .progress_trackers()
+                    .iter()
+                    .enumerate()
+                    .for_each(|(index, (item_spec_id, progress_tracker))| {
                         let progress_bar = progress_tracker.progress_bar();
-                        progress_bar.set_prefix(format!("{item_spec_id}"));
+
+                        // Hack: colourization done in `progress_begin` to get
+                        // numerical index to be colorized.
+                        let index = index + 1;
+                        cfg_if::cfg_if! {
+                            if #[cfg(feature = "output_colorized")] {
+                                match colorize {
+                                    CliColorize::Colored => {
+                                        // white
+                                        let index_colorized = console::Style::new()
+                                            .color256(15)
+                                            .apply_to(format!("{index}."));
+                                        // blue
+                                        let item_spec_id_colorized = console::Style::new()
+                                            .color256(75)
+                                            .apply_to(format!("{item_spec_id}"));
+                                        progress_bar.set_prefix(
+                                            format!("{index_colorized} {item_spec_id_colorized}")
+                                        );
+                                    }
+                                    CliColorize::Uncolored => {
+                                        progress_bar.set_prefix(format!("{index}. {item_spec_id}"));
+                                    }
+                                }
+                            } else {
+                                progress_bar.set_prefix(format!("{index}. {item_spec_id}"));
+                            }
+                        }
+
                         self.progress_bar_style_update(progress_tracker);
 
                         // Hack: This should be done with a timer in `ApplyCmd`.
                         // This uses threads, which is not WASM compatible.
                         progress_bar.enable_steady_tick(std::time::Duration::from_millis(100));
-                    },
-                );
+                    });
             }
             CliProgressFormat::Outcome => {
                 let progress_style = ProgressStyle::with_template("").unwrap_or_else(|error| {
@@ -454,8 +566,11 @@ where
                         // Status may have changed from `ExecPending` to
                         // `Running`.
                         //
-                        // We don't have the previous status though, so we use
-                        // the same style for both `ExecPending` and `Running`
+                        // We don't have the previous status though.
+                        //
+                        // TODO: Is this too much of a performance hit, and we send another message
+                        // for spinners?
+                        self.progress_bar_style_update(progress_tracker);
                     }
                     ProgressUpdate::Complete(progress_complete) => match progress_complete {
                         ProgressComplete::Success => {
@@ -502,6 +617,14 @@ where
 
     #[cfg(feature = "output_progress")]
     async fn progress_end(&mut self, cmd_progress_tracker: &CmdProgressTracker) {
+        // Hack: This should be done with a timer in `ApplyCmd`.
+        // This uses threads, which is not WASM compatible.
+        cmd_progress_tracker.progress_trackers().iter().for_each(
+            |(_item_spec_id, progress_tracker)| {
+                progress_tracker.progress_bar().disable_steady_tick();
+            },
+        );
+
         let _result = cmd_progress_tracker.multi_progress.clear();
     }
 

--- a/crate/rt_model_native/src/output/cli_output.rs
+++ b/crate/rt_model_native/src/output/cli_output.rs
@@ -386,11 +386,14 @@ where
         }
         let prefix = "{prefix:20}";
 
-        let progress_is_complete = matches!(
-            progress_tracker.progress_status(),
-            ProgressStatus::Complete(_)
-        );
-        let units = if progress_is_complete {
+        let (progress_is_complete, completion_is_successful) =
+            match progress_tracker.progress_status() {
+                ProgressStatus::Complete(progress_complete) => {
+                    (true, progress_complete.is_successful())
+                }
+                _ => (false, false),
+            };
+        let units = if progress_is_complete && completion_is_successful {
             None
         } else {
             progress_tracker

--- a/examples/app_cycle/Cargo.toml
+++ b/examples/app_cycle/Cargo.toml
@@ -38,7 +38,7 @@ whoami = "1.4.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 serde-wasm-bindgen = "0.5.0"

--- a/examples/app_cycle/src/cmds/env_clean_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_clean_cmd.rs
@@ -23,12 +23,14 @@ impl EnvCleanCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        let states_saved =
-            EnvCmd::run(output, |ctx| StatesSavedReadCmd::exec(ctx).boxed_local()).await?;
+        let states_saved = EnvCmd::run(output, true, |ctx| {
+            StatesSavedReadCmd::exec(ctx).boxed_local()
+        })
+        .await?;
 
         // https://github.com/rust-lang/rust-clippy/issues/10482
         #[allow(clippy::redundant_async_block)]
-        EnvCmd::run_and_present(output, |ctx| {
+        EnvCmd::run_and_present(output, false, |ctx| {
             async move { CleanCmd::exec(ctx, &states_saved).await }.boxed_local()
         })
         .await

--- a/examples/app_cycle/src/cmds/env_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_cmd.rs
@@ -46,7 +46,6 @@ impl EnvCmd {
                 >,
             >,
         ) -> LocalBoxFuture<'fn_once, Result<T, AppCycleError>>,
-        T: Presentable,
     {
         cmd_ctx_init!(output, cmd_ctx);
 

--- a/examples/app_cycle/src/cmds/env_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_cmd.rs
@@ -17,6 +17,7 @@ use peace::{
 use crate::{
     flows::EnvDeployFlow,
     model::{AppCycleError, EnvType},
+    rt_model::AppCycleCmdCtx,
 };
 
 /// Runs a `*Cmd` that accesses the environment.
@@ -72,15 +73,7 @@ impl EnvCmd {
     where
         O: OutputWrite<AppCycleError>,
         for<'fn_once> F: FnOnce(
-            &'fn_once mut CmdCtx<
-                SingleProfileSingleFlow<
-                    '_,
-                    AppCycleError,
-                    O,
-                    ParamsKeysImpl<KeyKnown<String>, KeyKnown<String>, KeyKnown<String>>,
-                    SetUp,
-                >,
-            >,
+            &'fn_once mut AppCycleCmdCtx<'_, O, SetUp>,
         ) -> LocalBoxFuture<'fn_once, Result<T, AppCycleError>>,
         T: Presentable,
     {
@@ -99,15 +92,7 @@ impl EnvCmd {
     }
 
     async fn profile_print<O>(
-        cmd_ctx: &mut CmdCtx<
-            SingleProfileSingleFlow<
-                '_,
-                AppCycleError,
-                O,
-                ParamsKeysImpl<KeyKnown<String>, KeyKnown<String>, KeyKnown<String>>,
-                SetUp,
-            >,
-        >,
+        cmd_ctx: &mut AppCycleCmdCtx<'_, O, SetUp>,
     ) -> Result<(), AppCycleError>
     where
         O: OutputWrite<AppCycleError>,

--- a/examples/app_cycle/src/cmds/env_deploy_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_deploy_cmd.rs
@@ -2,10 +2,7 @@ use futures::FutureExt;
 use peace::{
     cmd::scopes::SingleProfileSingleFlowView,
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{
-        sub::{StatesCurrentDiscoverCmd, StatesSavedReadCmd},
-        EnsureCmd,
-    },
+    rt::cmds::{sub::StatesSavedReadCmd, EnsureCmd},
     rt_model::output::OutputWrite,
 };
 
@@ -35,34 +32,31 @@ impl EnvDeployCmd {
         EnvCmd::run(output, false, |ctx| {
             async move {
                 let states_saved_ref = &states_saved;
-                let _states_ensured = EnsureCmd::exec(ctx, states_saved_ref).await?;
+                let states_ensured = EnsureCmd::exec(ctx, states_saved_ref).await?;
 
-                // TODO: there's a bug with states_ensured not being up to date after resuming
-                // from interruption.
-                let states_current = StatesCurrentDiscoverCmd::exec(ctx).await?;
-                let states_current_raw_map = &**states_current;
+                let states_ensured_raw_map = &**states_ensured;
 
                 let SingleProfileSingleFlowView { output, flow, .. } = ctx.view();
-                let states_current_presentables = {
-                    let states_current_presentables = flow
+                let states_ensured_presentables = {
+                    let states_ensured_presentables = flow
                         .graph()
                         .iter_insertion()
                         .map(|item_spec| {
                             let item_spec_id = item_spec.id();
-                            match states_current_raw_map.get(item_spec_id) {
-                                Some(state_current) => (item_spec_id, format!(": {state_current}")),
+                            match states_ensured_raw_map.get(item_spec_id) {
+                                Some(state_ensured) => (item_spec_id, format!(": {state_ensured}")),
                                 None => (item_spec_id, String::from(": <unknown>")),
                             }
                         })
                         .collect::<Vec<_>>();
 
-                    ListNumbered::new(states_current_presentables)
+                    ListNumbered::new(states_ensured_presentables)
                 };
 
                 output
                     .present(&(
-                        Heading::new(HeadingLevel::Level1, "States Current"),
-                        states_current_presentables,
+                        Heading::new(HeadingLevel::Level1, "States Ensured"),
+                        states_ensured_presentables,
                         "\n",
                     ))
                     .await?;

--- a/examples/app_cycle/src/cmds/env_deploy_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_deploy_cmd.rs
@@ -1,5 +1,7 @@
 use futures::FutureExt;
 use peace::{
+    cmd::scopes::SingleProfileSingleFlowView,
+    fmt::presentable::{Heading, HeadingLevel, ListNumbered},
     rt::cmds::{sub::StatesSavedReadCmd, EnsureCmd},
     rt_model::output::OutputWrite,
 };
@@ -27,13 +29,44 @@ impl EnvDeployCmd {
             StatesSavedReadCmd::exec(ctx).boxed_local()
         })
         .await?;
-        EnvCmd::run_and_present(output, false, |ctx| {
+        EnvCmd::run(output, false, |ctx| {
             async move {
                 let states_saved_ref = &states_saved;
-                EnsureCmd::exec(ctx, states_saved_ref).await
+                let states_ensured = EnsureCmd::exec(ctx, states_saved_ref).await?;
+
+                let states_ensured_raw_map = &**states_ensured;
+
+                let SingleProfileSingleFlowView { output, flow, .. } = ctx.view();
+                let states_ensured_presentables = {
+                    let states_ensured_presentables = flow
+                        .graph()
+                        .iter_insertion()
+                        .map(|item_spec| {
+                            let item_spec_id = item_spec.id();
+                            match states_ensured_raw_map.get(item_spec_id) {
+                                Some(state_ensured) => (item_spec_id, format!(": {state_ensured}")),
+                                None => (item_spec_id, String::from(": <unknown>")),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    ListNumbered::new(states_ensured_presentables)
+                };
+
+                output
+                    .present(&(
+                        Heading::new(HeadingLevel::Level1, "States Ensured"),
+                        states_ensured_presentables,
+                        "\n",
+                    ))
+                    .await?;
+
+                Ok(())
             }
             .boxed_local()
         })
-        .await
+        .await?;
+
+        Ok(())
     }
 }

--- a/examples/app_cycle/src/cmds/env_deploy_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_deploy_cmd.rs
@@ -2,7 +2,10 @@ use futures::FutureExt;
 use peace::{
     cmd::scopes::SingleProfileSingleFlowView,
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{sub::StatesSavedReadCmd, EnsureCmd},
+    rt::cmds::{
+        sub::{StatesCurrentDiscoverCmd, StatesSavedReadCmd},
+        EnsureCmd,
+    },
     rt_model::output::OutputWrite,
 };
 
@@ -32,31 +35,34 @@ impl EnvDeployCmd {
         EnvCmd::run(output, false, |ctx| {
             async move {
                 let states_saved_ref = &states_saved;
-                let states_ensured = EnsureCmd::exec(ctx, states_saved_ref).await?;
+                let _states_ensured = EnsureCmd::exec(ctx, states_saved_ref).await?;
 
-                let states_ensured_raw_map = &**states_ensured;
+                // TODO: there's a bug with states_ensured not being up to date after resuming
+                // from interruption.
+                let states_current = StatesCurrentDiscoverCmd::exec(ctx).await?;
+                let states_current_raw_map = &**states_current;
 
                 let SingleProfileSingleFlowView { output, flow, .. } = ctx.view();
-                let states_ensured_presentables = {
-                    let states_ensured_presentables = flow
+                let states_current_presentables = {
+                    let states_current_presentables = flow
                         .graph()
                         .iter_insertion()
                         .map(|item_spec| {
                             let item_spec_id = item_spec.id();
-                            match states_ensured_raw_map.get(item_spec_id) {
-                                Some(state_ensured) => (item_spec_id, format!(": {state_ensured}")),
+                            match states_current_raw_map.get(item_spec_id) {
+                                Some(state_current) => (item_spec_id, format!(": {state_current}")),
                                 None => (item_spec_id, String::from(": <unknown>")),
                             }
                         })
                         .collect::<Vec<_>>();
 
-                    ListNumbered::new(states_ensured_presentables)
+                    ListNumbered::new(states_current_presentables)
                 };
 
                 output
                     .present(&(
-                        Heading::new(HeadingLevel::Level1, "States Ensured"),
-                        states_ensured_presentables,
+                        Heading::new(HeadingLevel::Level1, "States Current"),
+                        states_current_presentables,
                         "\n",
                     ))
                     .await?;

--- a/examples/app_cycle/src/cmds/env_deploy_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_deploy_cmd.rs
@@ -23,9 +23,11 @@ impl EnvDeployCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        let states_saved =
-            EnvCmd::run(output, |ctx| StatesSavedReadCmd::exec(ctx).boxed_local()).await?;
-        EnvCmd::run_and_present(output, |ctx| {
+        let states_saved = EnvCmd::run(output, true, |ctx| {
+            StatesSavedReadCmd::exec(ctx).boxed_local()
+        })
+        .await?;
+        EnvCmd::run_and_present(output, false, |ctx| {
             async move {
                 let states_saved_ref = &states_saved;
                 EnsureCmd::exec(ctx, states_saved_ref).await

--- a/examples/app_cycle/src/cmds/env_desired_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_desired_cmd.rs
@@ -20,6 +20,9 @@ impl EnvDesiredCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        EnvCmd::run_and_present(output, |ctx| StatesDesiredReadCmd::exec(ctx).boxed_local()).await
+        EnvCmd::run_and_present(output, true, |ctx| {
+            StatesDesiredReadCmd::exec(ctx).boxed_local()
+        })
+        .await
     }
 }

--- a/examples/app_cycle/src/cmds/env_desired_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_desired_cmd.rs
@@ -1,5 +1,10 @@
 use futures::FutureExt;
-use peace::{rt::cmds::sub::StatesDesiredReadCmd, rt_model::output::OutputWrite};
+use peace::{
+    cmd::scopes::SingleProfileSingleFlowView,
+    fmt::presentable::{Heading, HeadingLevel, ListNumbered},
+    rt::cmds::sub::StatesDesiredReadCmd,
+    rt_model::output::OutputWrite,
+};
 
 use crate::{cmds::EnvCmd, model::AppCycleError};
 
@@ -20,9 +25,42 @@ impl EnvDesiredCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        EnvCmd::run_and_present(output, true, |ctx| {
-            StatesDesiredReadCmd::exec(ctx).boxed_local()
+        EnvCmd::run(output, true, |ctx| {
+            async {
+                let states_desired = StatesDesiredReadCmd::exec(ctx).await?;
+                let states_desired_raw_map = &**states_desired;
+
+                let SingleProfileSingleFlowView { output, flow, .. } = ctx.view();
+                let states_desired_presentables = {
+                    let states_desired_presentables = flow
+                        .graph()
+                        .iter_insertion()
+                        .map(|item_spec| {
+                            let item_spec_id = item_spec.id();
+                            match states_desired_raw_map.get(item_spec_id) {
+                                Some(state_desired) => (item_spec_id, format!(": {state_desired}")),
+                                None => (item_spec_id, String::from(": <unknown>")),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    ListNumbered::new(states_desired_presentables)
+                };
+
+                output
+                    .present(&(
+                        Heading::new(HeadingLevel::Level1, "States Desired"),
+                        states_desired_presentables,
+                        "\n",
+                    ))
+                    .await?;
+
+                Ok(())
+            }
+            .boxed_local()
         })
-        .await
+        .await?;
+
+        Ok(())
     }
 }

--- a/examples/app_cycle/src/cmds/env_discover_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_discover_cmd.rs
@@ -1,5 +1,9 @@
 use futures::FutureExt;
-use peace::{rt::cmds::StatesDiscoverCmd, rt_model::output::OutputWrite};
+use peace::{
+    fmt::presentable::{Heading, HeadingLevel},
+    rt::cmds::StatesDiscoverCmd,
+    rt_model::output::OutputWrite,
+};
 
 use crate::{cmds::EnvCmd, model::AppCycleError};
 
@@ -20,6 +24,19 @@ impl EnvDiscoverCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        EnvCmd::run_and_present(output, |ctx| StatesDiscoverCmd::exec(ctx).boxed_local()).await
+        let (states_current, states_desired) =
+            EnvCmd::run(output, |ctx| StatesDiscoverCmd::exec(ctx).boxed_local()).await?;
+
+        output
+            .present(&(
+                Heading::new(HeadingLevel::Level1, "States Current"),
+                &states_current,
+                "\n",
+                Heading::new(HeadingLevel::Level1, "States Desired"),
+                &states_desired,
+                "\n",
+            ))
+            .await?;
+        Ok(())
     }
 }

--- a/examples/app_cycle/src/cmds/env_discover_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_discover_cmd.rs
@@ -25,7 +25,7 @@ impl EnvDiscoverCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        EnvCmd::run(output, |ctx| {
+        EnvCmd::run(output, true, |ctx| {
             async {
                 let (states_current, states_desired) = StatesDiscoverCmd::exec(ctx).await?;
                 let states_current_raw_map = &**states_current;

--- a/examples/app_cycle/src/cmds/env_discover_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_discover_cmd.rs
@@ -1,6 +1,7 @@
 use futures::FutureExt;
 use peace::{
-    fmt::presentable::{Heading, HeadingLevel},
+    cmd::scopes::SingleProfileSingleFlowView,
+    fmt::presentable::{Heading, HeadingLevel, ListNumbered},
     rt::cmds::StatesDiscoverCmd,
     rt_model::output::OutputWrite,
 };
@@ -24,19 +25,61 @@ impl EnvDiscoverCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        let (states_current, states_desired) =
-            EnvCmd::run(output, |ctx| StatesDiscoverCmd::exec(ctx).boxed_local()).await?;
+        EnvCmd::run(output, |ctx| {
+            async {
+                let (states_current, states_desired) = StatesDiscoverCmd::exec(ctx).await?;
+                let states_current_raw_map = &**states_current;
+                let states_desired_raw_map = &**states_desired;
 
-        output
-            .present(&(
-                Heading::new(HeadingLevel::Level1, "States Current"),
-                &states_current,
-                "\n",
-                Heading::new(HeadingLevel::Level1, "States Desired"),
-                &states_desired,
-                "\n",
-            ))
-            .await?;
+                let SingleProfileSingleFlowView { output, flow, .. } = ctx.view();
+                let states_current_presentables = {
+                    let states_current_presentables = flow
+                        .graph()
+                        .iter_insertion()
+                        .map(|item_spec| {
+                            let item_spec_id = item_spec.id();
+                            match states_current_raw_map.get(item_spec_id) {
+                                Some(state_current) => (item_spec_id, format!(": {state_current}")),
+                                None => (item_spec_id, String::from(": <unknown>")),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    ListNumbered::new(states_current_presentables)
+                };
+                let states_desired_presentables = {
+                    let states_desired_presentables = flow
+                        .graph()
+                        .iter_insertion()
+                        .map(|item_spec| {
+                            let item_spec_id = item_spec.id();
+                            match states_desired_raw_map.get(item_spec_id) {
+                                Some(state_desired) => (item_spec_id, format!(": {state_desired}")),
+                                None => (item_spec_id, String::from(": <unknown>")),
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    ListNumbered::new(states_desired_presentables)
+                };
+
+                output
+                    .present(&(
+                        Heading::new(HeadingLevel::Level1, "States Current"),
+                        states_current_presentables,
+                        "\n",
+                        Heading::new(HeadingLevel::Level1, "States Desired"),
+                        states_desired_presentables,
+                        "\n",
+                    ))
+                    .await?;
+
+                Ok(())
+            }
+            .boxed_local()
+        })
+        .await?;
+
         Ok(())
     }
 }

--- a/examples/app_cycle/src/cmds/env_status_cmd.rs
+++ b/examples/app_cycle/src/cmds/env_status_cmd.rs
@@ -20,6 +20,9 @@ impl EnvStatusCmd {
     where
         O: OutputWrite<AppCycleError> + Send,
     {
-        EnvCmd::run_and_present(output, |ctx| StatesSavedReadCmd::exec(ctx).boxed_local()).await
+        EnvCmd::run_and_present(output, true, |ctx| {
+            StatesSavedReadCmd::exec(ctx).boxed_local()
+        })
+        .await
     }
 }

--- a/examples/app_cycle/src/main.rs
+++ b/examples/app_cycle/src/main.rs
@@ -41,20 +41,26 @@ pub fn main() -> peace::miette::Result<(), peace::miette::Report> {
 }
 
 pub fn run() -> Result<(), AppCycleError> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .thread_name("main")
-        .thread_stack_size(3 * 1024 * 1024)
-        .enable_io()
-        .enable_time()
-        .build()
-        .map_err(AppCycleError::TokioRuntimeInit)?;
-
     let CliArgs {
         command,
+        fast,
         format,
         #[cfg(feature = "output_colorized")]
         color,
     } = CliArgs::parse();
+
+    let runtime = if fast {
+        tokio::runtime::Builder::new_multi_thread()
+    } else {
+        tokio::runtime::Builder::new_current_thread()
+    }
+    .thread_name("main")
+    .thread_stack_size(3 * 1024 * 1024)
+    .enable_io()
+    .enable_time()
+    .build()
+    .map_err(AppCycleError::TokioRuntimeInit)?;
+
     #[allow(unused_assignments)]
     runtime.block_on(async {
         let _workspace_spec = WorkspaceSpec::WorkingDir;

--- a/examples/app_cycle/src/model/cli_args.rs
+++ b/examples/app_cycle/src/model/cli_args.rs
@@ -19,6 +19,9 @@ pub struct CliArgs {
     /// Command to run.
     #[command(subcommand)]
     pub command: AppCycleCommand,
+    /// Whether to run with multiple threads.
+    #[arg(long, default_value = "false")]
+    pub fast: bool,
     /// The format of the command output.
     ///
     /// At this level, this needs to be specified before the subcommand.

--- a/examples/app_cycle/src/rt_model/app_cycle_cmd_ctx.rs
+++ b/examples/app_cycle/src/rt_model/app_cycle_cmd_ctx.rs
@@ -1,6 +1,6 @@
 use peace::{
     cmd::scopes::SingleProfileSingleFlow,
-    rt_model::params::{KeyKnown, KeyUnknown, ParamsKeysImpl},
+    rt_model::params::{KeyKnown, ParamsKeysImpl},
 };
 
 use crate::model::AppCycleError;
@@ -11,7 +11,7 @@ pub type AppCycleCmdCtx<'ctx, O, TS> = peace::cmd::ctx::CmdCtx<
         'ctx,
         AppCycleError,
         O,
-        ParamsKeysImpl<KeyKnown<String>, KeyKnown<String>, KeyUnknown>,
+        ParamsKeysImpl<KeyKnown<String>, KeyKnown<String>, KeyKnown<String>>,
         TS,
     >,
 >;

--- a/workspace_tests/src/fmt/presentable.rs
+++ b/workspace_tests/src/fmt/presentable.rs
@@ -21,11 +21,11 @@ async fn ref_t_is_presentable_when_t_is_presentable() -> Result<(), Box<dyn std:
 }
 
 #[tokio::test]
-async fn str_is_presentable() -> Result<(), Box<dyn std::error::Error>> {
+async fn ref_str_is_presentable() -> Result<(), Box<dyn std::error::Error>> {
     let mut presenter = FnTrackerPresenter::new();
 
     let s = "hello";
-    <str as Presentable>::present(s, &mut presenter).await?;
+    <&str as Presentable>::present(&s, &mut presenter).await?;
 
     assert_eq!(
         vec![FnInvocation::new(

--- a/workspace_tests/src/fn_tracker_output.rs
+++ b/workspace_tests/src/fn_tracker_output.rs
@@ -53,12 +53,12 @@ where
     #[cfg(feature = "output_progress")]
     async fn progress_end(&mut self, _cmd_progress_tracker: &CmdProgressTracker) {}
 
-    async fn present<P>(&mut self, presentable: &P) -> Result<(), E>
+    async fn present<P>(&mut self, presentable: P) -> Result<(), E>
     where
-        P: Presentable + ?Sized,
+        P: Presentable,
     {
         let presentable_serialized =
-            serde_yaml::to_string(presentable).map_err(rt_model::Error::PresentableSerialize)?;
+            serde_yaml::to_string(&presentable).map_err(rt_model::Error::PresentableSerialize)?;
         self.fn_invocations.push(FnInvocation::new(
             "present",
             vec![Some(presentable_serialized)],

--- a/workspace_tests/src/fn_tracker_presenter.rs
+++ b/workspace_tests/src/fn_tracker_presenter.rs
@@ -1,4 +1,4 @@
-use peace::fmt::{async_trait, Presentable, Presenter};
+use peace::fmt::{async_trait, presentable::HeadingLevel, Presentable, Presenter};
 
 use crate::{fn_name::fn_name_short, FnInvocation};
 
@@ -27,6 +27,21 @@ impl FnTrackerPresenter {
 impl Presenter<'static> for FnTrackerPresenter {
     type Error = std::io::Error;
 
+    async fn heading<P>(
+        &mut self,
+        heading_level: HeadingLevel,
+        _presentable: &P,
+    ) -> Result<(), Self::Error>
+    where
+        P: Presentable + ?Sized,
+    {
+        self.fn_invocations.push(FnInvocation::new(
+            fn_name_short!(),
+            vec![Some(format!("{heading_level:?}")), None],
+        ));
+        Ok(())
+    }
+
     async fn id(&mut self, id: &str) -> Result<(), Self::Error> {
         self.fn_invocations.push(FnInvocation::new(
             fn_name_short!(),
@@ -48,6 +63,15 @@ impl Presenter<'static> for FnTrackerPresenter {
             fn_name_short!(),
             vec![Some(format!("{text:?}"))],
         ));
+        Ok(())
+    }
+
+    async fn bold<P>(&mut self, _presentable: &P) -> Result<(), Self::Error>
+    where
+        P: Presentable + ?Sized,
+    {
+        self.fn_invocations
+            .push(FnInvocation::new(fn_name_short!(), vec![None]));
         Ok(())
     }
 

--- a/workspace_tests/src/no_op_output.rs
+++ b/workspace_tests/src/no_op_output.rs
@@ -32,9 +32,9 @@ where
     #[cfg(feature = "output_progress")]
     async fn progress_end(&mut self, _cmd_progress_tracker: &CmdProgressTracker) {}
 
-    async fn present<P>(&mut self, _presentable: &P) -> Result<(), E>
+    async fn present<P>(&mut self, _presentable: P) -> Result<(), E>
     where
-        P: Presentable + ?Sized,
+        P: Presentable,
     {
         Ok(())
     }

--- a/workspace_tests/src/rt_model/output/cli_output.rs
+++ b/workspace_tests/src/rt_model/output/cli_output.rs
@@ -12,8 +12,6 @@ use peace::rt_model::output::CliColorizeOpt;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {
-        use std::collections::HashMap;
-
         use peace::{
             cfg::progress::{
                 ProgressComplete,
@@ -29,6 +27,7 @@ cfg_if::cfg_if! {
                 indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget},
                 output::{CliOutputTarget, CliProgressFormatOpt},
                 CmdProgressTracker,
+                IndexMap,
             },
         };
     }
@@ -1500,7 +1499,7 @@ fn cmd_progress_tracker(cli_output: &CliOutput<&mut Vec<u8>>) -> (CmdProgressTra
     let multi_progress = MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(
         in_memory_term.clone(),
     )));
-    let mut progress_trackers = HashMap::new();
+    let mut progress_trackers = IndexMap::new();
     let progress_bar = multi_progress.add(ProgressBar::hidden());
     let progress_tracker = ProgressTracker::new(progress_bar.clone());
     progress_trackers.insert(item_spec_id!("test_item_spec_id"), progress_tracker);

--- a/workspace_tests/src/rt_model/output/cli_output.rs
+++ b/workspace_tests/src/rt_model/output/cli_output.rs
@@ -320,14 +320,17 @@ mod color_always {
 
         // We can't inspect `ProgressStyle`'s fields, so we have to render the progress
         // and compare the output.
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!(
+            "\u{1b}[38;5;15m1.\u{1b}[0m \u{1b}[38;5;75mtest_item_spec_id\u{1b}[0m",
+            progress_bar.prefix()
+        );
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▏ (el: 0s, eta: 0s)"#,
-            // ^                   ^ ^                                      ^
-            // '---- 20 chars -----' '-------------- 40 chars --------------'
+            r#"⏳ 1. test_item_spec_id ▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ (el: 0s, eta: 0s)"#,
+            //    ^                  ^ ^                                      ^
+            //    '---- 20 chars ----' '-------------- 40 chars --------------'
             in_memory_term.contents()
         );
     }
@@ -359,6 +362,7 @@ mod color_always {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -373,23 +377,26 @@ mod color_always {
         )
         .await;
 
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!(
+            "\u{1b}[38;5;15m1.\u{1b}[0m \u{1b}[38;5;75mtest_item_spec_id\u{1b}[0m",
+            progress_bar.prefix()
+        );
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(21);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▍                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 21/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(22);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▊                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 22/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
     }
@@ -421,6 +428,7 @@ mod color_always {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -441,7 +449,7 @@ mod color_always {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -463,7 +471,7 @@ mod color_always {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"✅ test_item_spec_id    ▕████████████████████████████████████████▏ done"#,
+            r#"✅ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰ done"#,
             in_memory_term.contents(),
         );
     }
@@ -495,6 +503,7 @@ mod color_always {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -515,7 +524,7 @@ mod color_always {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -537,7 +546,7 @@ mod color_always {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"❌ test_item_spec_id    ▕████████                                ▏ done"#,
+            r#"❌ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 done"#,
             in_memory_term.contents()
         );
     }
@@ -581,6 +590,7 @@ mod color_always {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -652,6 +662,7 @@ msg_update: NoChange"#,
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -702,14 +713,14 @@ mod color_never {
 
         // We can't inspect `ProgressStyle`'s fields, so we have to render the progress
         // and compare the output.
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!("1. test_item_spec_id", progress_bar.prefix());
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▏ (el: 0s, eta: 0s)"#,
-            // ^                   ^ ^                                      ^
-            // '---- 20 chars -----' '-------------- 40 chars --------------'
+            r#"⏳ 1. test_item_spec_id ▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ (el: 0s, eta: 0s)"#,
+            //    ^                  ^ ^                                      ^
+            //    '---- 20 chars ----' '-------------- 40 chars --------------'
             in_memory_term.contents()
         );
     }
@@ -741,6 +752,7 @@ mod color_never {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -755,23 +767,23 @@ mod color_never {
         )
         .await;
 
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!("1. test_item_spec_id", progress_bar.prefix());
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(21);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▍                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 21/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(22);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▊                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 22/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
     }
@@ -803,6 +815,7 @@ mod color_never {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -823,7 +836,7 @@ mod color_never {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -845,7 +858,7 @@ mod color_never {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"✅ test_item_spec_id    ▕████████████████████████████████████████▏ done"#,
+            r#"✅ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰ done"#,
             in_memory_term.contents(),
         );
     }
@@ -877,6 +890,7 @@ mod color_never {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -897,7 +911,7 @@ mod color_never {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -919,7 +933,7 @@ mod color_never {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"❌ test_item_spec_id    ▕████████                                ▏ done"#,
+            r#"❌ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 done"#,
             in_memory_term.contents()
         );
     }
@@ -963,6 +977,7 @@ mod color_never {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1034,6 +1049,7 @@ msg_update: NoChange"#,
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1083,14 +1099,14 @@ mod color_disabled {
 
         // We can't inspect `ProgressStyle`'s fields, so we have to render the progress
         // and compare the output.
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!("1. test_item_spec_id", progress_bar.prefix());
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▏ (el: 0s, eta: 0s)"#,
-            // ^                   ^ ^                                      ^
-            // '---- 20 chars -----' '-------------- 40 chars --------------'
+            r#"⏳ 1. test_item_spec_id ▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ (el: 0s, eta: 0s)"#,
+            //    ^                  ^ ^                                      ^
+            //    '---- 20 chars ----' '-------------- 40 chars --------------'
             in_memory_term.contents()
         );
     }
@@ -1121,6 +1137,7 @@ mod color_disabled {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1135,23 +1152,23 @@ mod color_disabled {
         )
         .await;
 
-        assert_eq!("test_item_spec_id", progress_bar.prefix());
+        assert_eq!("1. test_item_spec_id", progress_bar.prefix());
         let CliOutputTarget::InMemory(in_memory_term) = cli_output.progress_target() else {
             unreachable!("This is set in `cli_output_progress`.");
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(21);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▍                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 21/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
         progress_bar.set_position(22);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████▊                               ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 22/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
     }
@@ -1182,6 +1199,7 @@ mod color_disabled {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1202,7 +1220,7 @@ mod color_disabled {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -1224,7 +1242,7 @@ mod color_disabled {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"✅ test_item_spec_id    ▕████████████████████████████████████████▏ done"#,
+            r#"✅ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰ done"#,
             in_memory_term.contents(),
         );
     }
@@ -1255,6 +1273,7 @@ mod color_disabled {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1275,7 +1294,7 @@ mod color_disabled {
         };
         progress_bar.set_position(20);
         assert_eq!(
-            r#"⏳ test_item_spec_id    ▕████████                                ▏ (el: 0s, eta: 0s)"#,
+            r#"⏳ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 (el: 0s, eta: 0s)"#,
             in_memory_term.contents()
         );
 
@@ -1297,7 +1316,7 @@ mod color_disabled {
             unreachable!("This is set in `cli_output_progress`.");
         };
         assert_eq!(
-            r#"❌ test_item_spec_id    ▕████████                                ▏ done"#,
+            r#"❌ 1. test_item_spec_id ▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 20/100 done"#,
             in_memory_term.contents()
         );
     }
@@ -1340,6 +1359,7 @@ mod color_disabled {
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {
@@ -1410,6 +1430,7 @@ msg_update: NoChange"#,
 
         // Adjust progress_bar length and units.
         progress_tracker.set_progress_status(ProgressStatus::Running);
+        progress_tracker.set_progress_limit(ProgressLimit::Steps(100));
         progress_bar.set_length(100);
 
         let progress_update_and_id = ProgressUpdateAndId {


### PR DESCRIPTION
Closes #91 -- though this is handled at the application level, not by the framework.

* Include entry for current and discovered states, and diff in `app_cycle` example.
* Sort progress bars based on insertion order.
* Use `▰` and `▱` parallelogram characters for progress bars.
* Spinner progress is now rendered.