### PR TITLE
Raise error when spec not provided on subsequent `CmdCtx`, when previously a `MappingFn` was provided.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Install `wasm-pack`'
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'v0.10.3'
+          version: 'v0.11.1'
 
       - name: mdbook-graphviz Cache
         id: mdbook_graphviz_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - name: 'Install `wasm-pack`'
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'v0.10.3'
+          version: 'v0.11.1'
 
       # When updating this, also update book.yml
       - name: 'Build examples'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Take in `Params::Spec`s in `CmdCtxBuilder::with_item_spec_params`. ([#94], [#118])
 * Use `Params::Partial` in `ItemSpec::try_state_*` functions. ([#94], [#118])
 * Implement one level recursion referential item spec params. ([#119], [#121])
+* Implement deep merging of params specs. ([#122], [#123])
 
 [#116]: https://github.com/azriel91/peace/issues/116
 [#117]: https://github.com/azriel91/peace/pull/117
@@ -18,6 +19,8 @@
 [#118]: https://github.com/azriel91/peace/pull/118
 [#119]: https://github.com/azriel91/peace/issues/119
 [#121]: https://github.com/azriel91/peace/pull/121
+[#122]: https://github.com/azriel91/peace/issues/122
+[#123]: https://github.com/azriel91/peace/pull/123
 
 
 ## 0.0.9 (2023-04-13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ miette = { version = "5.7.0" }
 tar = "0.4.38"
 tokio = "1.27.0"
 tynm = "0.1.7"
-type_reg = { version = "0.5.0", features = ["debug", "untagged", "ordered"] }
+type_reg = { version = "0.5.1", features = ["debug", "untagged", "ordered"] }
 
 [features]
 default = []

--- a/crate/cmd/src/ctx/cmd_ctx_builder.rs
+++ b/crate/cmd/src/ctx/cmd_ctx_builder.rs
@@ -315,7 +315,7 @@ where
                     Some((item_spec_id, mut params_spec_provided)),
                     Some((_item_spec_id, params_spec_stored)),
                 ) => {
-                    params_spec_provided.merge(&params_spec_stored);
+                    params_spec_provided.merge(&*params_spec_stored);
                     Some((item_spec_id, params_spec_provided))
                 }
             };

--- a/crate/params/Cargo.toml
+++ b/crate/params/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 test = false
 
 [dependencies]
+downcast-rs = "1.2.0"
 dyn-clone = "1.0.11"
 erased-serde = "0.3.25"
 miette = { workspace = true, optional = true }

--- a/crate/params/src/any_spec_data_type.rs
+++ b/crate/params/src/any_spec_data_type.rs
@@ -1,0 +1,31 @@
+use std::{any::Any, fmt};
+
+use dyn_clone::DynClone;
+use peace_resources::type_reg::untagged::DataType;
+
+use crate::AnySpecRt;
+
+/// A [`DataType`] that is also an [`AnySpecRt`].
+pub trait AnySpecDataType: DataType + AnySpecRt {}
+
+impl<T> AnySpecDataType for T where
+    T: Any + DynClone + fmt::Debug + AnySpecRt + erased_serde::Serialize + Send + Sync
+{
+}
+
+downcast_rs::impl_downcast!(sync AnySpecDataType);
+
+impl Clone for Box<dyn AnySpecDataType> {
+    fn clone(&self) -> Self {
+        dyn_clone::clone_box(self.as_ref())
+    }
+}
+
+impl<'a> serde::Serialize for dyn AnySpecDataType + 'a {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        erased_serde::serialize(self, serializer)
+    }
+}

--- a/crate/params/src/any_spec_rt.rs
+++ b/crate/params/src/any_spec_rt.rs
@@ -1,4 +1,4 @@
-use crate::AnySpecRtBoxed;
+use crate::AnySpecDataType;
 
 /// Runtime logic of how to look up values for each field in this struct.
 ///
@@ -27,7 +27,7 @@ pub trait AnySpecRt {
     /// This can't be `Self` or `&Self` because that makes the trait non-object
     /// safe. Adding a `where: Self: Sized` bound prevents the method from being
     /// called from `cmd_ctx_builder`.
-    fn merge(&mut self, other: &AnySpecRtBoxed);
+    fn merge(&mut self, other: &dyn AnySpecDataType);
 }
 
 impl<T> AnySpecRt for Box<T>
@@ -38,7 +38,7 @@ where
         self.as_ref().is_usable()
     }
 
-    fn merge(&mut self, other: &AnySpecRtBoxed)
+    fn merge(&mut self, other: &dyn AnySpecDataType)
     where
         Self: Sized,
     {

--- a/crate/params/src/any_spec_rt.rs
+++ b/crate/params/src/any_spec_rt.rs
@@ -1,0 +1,22 @@
+/// Runtime logic of how to look up values for each field in this struct.
+///
+/// This trait is automatically implemented by `#[derive(Params)]` on an
+/// `ItemSpec::Params`, as well as in the `peace_params` crate for standard
+/// library types.
+pub trait AnySpecRt {
+    /// Whether this `Spec` is usable to resolve values.
+    ///
+    /// This is only `false` for `*Spec::MappingFn`s that have been
+    /// deserialized, as mapping functions cannot be deserialized back into
+    /// logic without embedding a script interpreter or compiler.
+    fn is_usable(&self) -> bool;
+}
+
+impl<T> AnySpecRt for Box<T>
+where
+    T: AnySpecRt + ?Sized,
+{
+    fn is_usable(&self) -> bool {
+        self.as_ref().is_usable()
+    }
+}

--- a/crate/params/src/any_spec_rt.rs
+++ b/crate/params/src/any_spec_rt.rs
@@ -1,3 +1,5 @@
+use crate::AnySpecRtBoxed;
+
 /// Runtime logic of how to look up values for each field in this struct.
 ///
 /// This trait is automatically implemented by `#[derive(Params)]` on an
@@ -10,13 +12,36 @@ pub trait AnySpecRt {
     /// deserialized, as mapping functions cannot be deserialized back into
     /// logic without embedding a script interpreter or compiler.
     fn is_usable(&self) -> bool;
+    /// Deep merges the provided `AnySpecRt` with `self`, where `self` takes
+    /// priority, except for `Self::Stored`.
+    ///
+    /// This means where `self` is `Self::Value`, `Self::InMemory`,
+    /// `Self::MappingFn`, and `Self::FieldWise`, these would take priority over
+    /// any stored item spec variants.
+    ///
+    /// For `Self::FieldWise`, a recursive merge would happen per field
+    /// `ValueSpec`.
+    ///
+    /// # Design
+    ///
+    /// This can't be `Self` or `&Self` because that makes the trait non-object
+    /// safe. Adding a `where: Self: Sized` bound prevents the method from being
+    /// called from `cmd_ctx_builder`.
+    fn merge(&mut self, other: &AnySpecRtBoxed);
 }
 
 impl<T> AnySpecRt for Box<T>
 where
-    T: AnySpecRt + ?Sized,
+    T: AnySpecRt,
 {
     fn is_usable(&self) -> bool {
         self.as_ref().is_usable()
+    }
+
+    fn merge(&mut self, other: &AnySpecRtBoxed)
+    where
+        Self: Sized,
+    {
+        self.as_mut().merge(other)
     }
 }

--- a/crate/params/src/any_spec_rt_boxed.rs
+++ b/crate/params/src/any_spec_rt_boxed.rs
@@ -31,13 +31,13 @@ impl Deref for AnySpecRtBoxed {
     type Target = dyn AnySpecDataType;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0.as_ref()
     }
 }
 
 impl DerefMut for AnySpecRtBoxed {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.0.as_mut()
     }
 }
 

--- a/crate/params/src/any_spec_rt_boxed.rs
+++ b/crate/params/src/any_spec_rt_boxed.rs
@@ -1,0 +1,82 @@
+use std::ops::{Deref, DerefMut};
+
+use peace_resources::type_reg::{
+    untagged::{BoxDataTypeDowncast, DataType, DataTypeWrapper, FromDataType},
+    TypeNameLit,
+};
+use serde::Serialize;
+
+use crate::{AnySpecDataType, AnySpecRt};
+
+/// Box of a [`DataType`] that is also a [`ValueSpecRt`].
+#[derive(Clone, Debug, Serialize)]
+pub struct AnySpecRtBoxed(pub(crate) Box<dyn AnySpecDataType>);
+
+impl AnySpecRtBoxed {
+    /// Returns a new `ValueSpecRtBoxed` wrapper around the provided type.
+    pub fn new<T>(t: T) -> Self
+    where
+        T: DataType + AnySpecRt,
+    {
+        Self(Box::new(t))
+    }
+
+    /// Returns the inner `Box<dyn ValueSpecDataType>`.
+    pub fn into_inner(self) -> Box<dyn AnySpecDataType> {
+        self.0
+    }
+}
+
+impl Deref for AnySpecRtBoxed {
+    type Target = dyn AnySpecDataType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AnySpecRtBoxed {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> FromDataType<T> for AnySpecRtBoxed
+where
+    T: DataType + AnySpecRt,
+{
+    fn from(t: T) -> Self {
+        AnySpecRtBoxed(Box::new(t))
+    }
+}
+
+impl<T> BoxDataTypeDowncast<T> for AnySpecRtBoxed
+where
+    T: DataType + AnySpecRt,
+{
+    fn downcast_ref(&self) -> Option<&T> {
+        self.0.downcast_ref::<T>()
+    }
+
+    fn downcast_mut(&mut self) -> Option<&mut T> {
+        self.0.downcast_mut::<T>()
+    }
+}
+
+impl DataTypeWrapper for AnySpecRtBoxed {
+    fn type_name(&self) -> TypeNameLit {
+        DataType::type_name(&*self.0)
+    }
+
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+
+    fn debug(&self) -> &dyn std::fmt::Debug {
+        &self.0
+    }
+
+    fn inner(&self) -> &dyn DataType {
+        &self.0
+    }
+}

--- a/crate/params/src/field_wise_spec_rt.rs
+++ b/crate/params/src/field_wise_spec_rt.rs
@@ -37,4 +37,11 @@ pub trait FieldWiseSpecRt {
         resources: &Resources<SetUp>,
         value_resolution_ctx: &mut ValueResolutionCtx,
     ) -> Result<Self::Partial, ParamsResolveError>;
+
+    /// Whether this `Spec` is usable to resolve values.
+    ///
+    /// This is only `false` for `*Spec::MappingFn`s that have been
+    /// deserialized, as mapping functions cannot be deserialized back into
+    /// logic without embedding a script interpreter or compiler.
+    fn is_usable(&self) -> bool;
 }

--- a/crate/params/src/field_wise_spec_rt.rs
+++ b/crate/params/src/field_wise_spec_rt.rs
@@ -3,14 +3,14 @@ use std::fmt::Debug;
 use peace_resources::{resources::ts::SetUp, Resources};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{ParamsResolveError, ValueResolutionCtx};
+use crate::{AnySpecRt, ParamsResolveError, ValueResolutionCtx};
 
 /// Runtime logic of how to look up values for each field in this struct.
 ///
 /// This trait is automatically implemented by `#[derive(Params)]` on an
 /// `ItemSpec::Params`, as well as manual implementations for standard library
 /// types.
-pub trait FieldWiseSpecRt {
+pub trait FieldWiseSpecRt: AnySpecRt {
     /// The original value type. `MyParamsFieldWiseSpec::ValueType` is
     /// `MyParams`.
     type ValueType: Clone + Debug + Serialize + DeserializeOwned + Send + Sync + 'static;
@@ -37,11 +37,4 @@ pub trait FieldWiseSpecRt {
         resources: &Resources<SetUp>,
         value_resolution_ctx: &mut ValueResolutionCtx,
     ) -> Result<Self::Partial, ParamsResolveError>;
-
-    /// Whether this `Spec` is usable to resolve values.
-    ///
-    /// This is only `false` for `*Spec::MappingFn`s that have been
-    /// deserialized, as mapping functions cannot be deserialized back into
-    /// logic without embedding a script interpreter or compiler.
-    fn is_usable(&self) -> bool;
 }

--- a/crate/params/src/lib.rs
+++ b/crate/params/src/lib.rs
@@ -64,6 +64,7 @@ pub use peace_params_derive::{value_impl, Params, ParamsFieldless};
 pub use tynm;
 
 pub use crate::{
+    any_spec_data_type::AnySpecDataType, any_spec_rt::AnySpecRt, any_spec_rt_boxed::AnySpecRtBoxed,
     field_name_and_type::FieldNameAndType, field_wise_spec_rt::FieldWiseSpecRt,
     mapping_fn::MappingFn, mapping_fn_impl::MappingFnImpl, params::Params,
     params_fieldless::ParamsFieldless, params_resolve_error::ParamsResolveError,
@@ -74,6 +75,9 @@ pub use crate::{
     value_spec_rt::ValueSpecRt,
 };
 
+mod any_spec_data_type;
+mod any_spec_rt;
+mod any_spec_rt_boxed;
 mod field_name_and_type;
 mod field_wise_spec_rt;
 mod mapping_fn;

--- a/crate/params/src/mapping_fn.rs
+++ b/crate/params/src/mapping_fn.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use peace_resources::{resources::ts::SetUp, type_reg::untagged::DataType, Resources};
 use serde::{Serialize, Serializer};
 
@@ -7,7 +9,7 @@ use crate::{ParamsResolveError, ValueResolutionCtx};
 ///
 /// This is used by Peace to hold type-erased mapping functions, and is not
 /// intended to be implemented by users or implementors.
-pub trait MappingFn: DataType {
+pub trait MappingFn: Debug + DataType {
     /// Type that is output by the function.
     type Output;
 

--- a/crate/params/src/params_spec.rs
+++ b/crate/params/src/params_spec.rs
@@ -226,4 +226,12 @@ where
             .map(T::try_from)
             .map(Result::ok)
     }
+
+    fn is_usable(&self) -> bool {
+        match self {
+            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
+            Self::FieldWise { field_wise_spec } => field_wise_spec.is_usable(),
+        }
+    }
 }

--- a/crate/params/src/params_spec.rs
+++ b/crate/params/src/params_spec.rs
@@ -207,7 +207,8 @@ where
 {
     fn is_usable(&self) -> bool {
         match self {
-            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::Stored => false,
+            Self::Value { .. } | Self::InMemory => true,
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
             Self::FieldWise { field_wise_spec } => field_wise_spec.is_usable(),
         }

--- a/crate/params/src/params_spec.rs
+++ b/crate/params/src/params_spec.rs
@@ -4,8 +4,8 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, FieldWiseSpecRt, MappingFn, MappingFnImpl, Params, ParamsResolveError,
-    ValueResolutionCtx, ValueSpecRt,
+    AnySpecRt, AnySpecRtBoxed, FieldWiseSpecRt, MappingFn, MappingFnImpl, Params,
+    ParamsResolveError, ValueResolutionCtx, ValueSpecRt,
 };
 
 /// How to populate a field's value in an item spec's params.
@@ -210,6 +210,38 @@ where
             Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
             Self::FieldWise { field_wise_spec } => field_wise_spec.is_usable(),
+        }
+    }
+
+    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    where
+        Self: Sized,
+    {
+        let other: Option<&Self> = other_boxed.downcast_ref();
+        let Some(other) = other else {
+            let self_ty_name = tynm::type_name::<Self>();
+            panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.");
+        };
+        match self {
+            // Use the spec that was previously stored
+            // (as opposed to previous value).
+            Self::Stored => *self = other.clone(),
+
+            // Use set value / no change on these variants
+            Self::Value { .. } | Self::InMemory | Self::MappingFn(_) => {}
+
+            //
+            Self::FieldWise { field_wise_spec } => {
+                match other {
+                    // Don't merge stored field wise specs over provided specs.
+                    Self::Stored | Self::Value { .. } | Self::InMemory | Self::MappingFn(_) => {}
+
+                    // Merge specs fieldwise.
+                    Self::FieldWise {
+                        field_wise_spec: field_wise_spec_other,
+                    } => AnySpecRt::merge(field_wise_spec, field_wise_spec_other),
+                }
+            }
         }
     }
 }

--- a/crate/params/src/params_spec.rs
+++ b/crate/params/src/params_spec.rs
@@ -4,7 +4,7 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, AnySpecRtBoxed, FieldWiseSpecRt, MappingFn, MappingFnImpl, Params,
+    AnySpecDataType, AnySpecRt, FieldWiseSpecRt, MappingFn, MappingFnImpl, Params,
     ParamsResolveError, ValueResolutionCtx, ValueSpecRt,
 };
 
@@ -213,7 +213,7 @@ where
         }
     }
 
-    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    fn merge(&mut self, other_boxed: &dyn AnySpecDataType)
     where
         Self: Sized,
     {

--- a/crate/params/src/params_spec.rs
+++ b/crate/params/src/params_spec.rs
@@ -115,7 +115,7 @@ where
             Self::Stored => f.write_str("Stored"),
             Self::Value { value } => f.debug_tuple("Value").field(value).finish(),
             Self::InMemory => f.write_str("From"),
-            Self::MappingFn(_) => f.debug_tuple("MappingFn").field(&"..").finish(),
+            Self::MappingFn(mapping_fn) => f.debug_tuple("MappingFn").field(mapping_fn).finish(),
             Self::FieldWise { field_wise_spec } => {
                 f.debug_tuple("FieldWise").field(field_wise_spec).finish()
             }

--- a/crate/params/src/params_spec_fieldless.rs
+++ b/crate/params/src/params_spec_fieldless.rs
@@ -184,7 +184,8 @@ where
 {
     fn is_usable(&self) -> bool {
         match self {
-            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::Stored => false,
+            Self::Value { .. } | Self::InMemory => true,
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
         }
     }

--- a/crate/params/src/params_spec_fieldless.rs
+++ b/crate/params/src/params_spec_fieldless.rs
@@ -4,8 +4,8 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, MappingFn, MappingFnImpl, ParamsFieldless, ParamsResolveError, ValueResolutionCtx,
-    ValueSpecRt,
+    AnySpecRt, AnySpecRtBoxed, MappingFn, MappingFnImpl, ParamsFieldless, ParamsResolveError,
+    ValueResolutionCtx, ValueSpecRt,
 };
 
 /// How to populate a field's value in an item spec's params.
@@ -174,7 +174,13 @@ where
 
 impl<T> AnySpecRt for ParamsSpecFieldless<T>
 where
-    T: ParamsFieldless<Spec = ParamsSpecFieldless<T>> + Clone + Debug + Send + Sync + 'static,
+    T: ParamsFieldless<Spec = ParamsSpecFieldless<T>>
+        + Clone
+        + Debug
+        + Serialize
+        + Send
+        + Sync
+        + 'static,
 {
     fn is_usable(&self) -> bool {
         match self {
@@ -182,11 +188,36 @@ where
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
         }
     }
+
+    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    where
+        Self: Sized,
+    {
+        let other: Option<&Self> = other_boxed.downcast_ref();
+        let Some(other) = other else {
+            let self_ty_name = tynm::type_name::<Self>();
+            panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.");
+        };
+        match self {
+            // Use the spec that was previously stored
+            // (as opposed to previous value).
+            Self::Stored => *self = other.clone(),
+
+            // Use set value / no change on these variants
+            Self::Value { .. } | Self::InMemory | Self::MappingFn(_) => {}
+        }
+    }
 }
 
 impl<T> ValueSpecRt for ParamsSpecFieldless<T>
 where
-    T: ParamsFieldless<Spec = ParamsSpecFieldless<T>> + Clone + Debug + Send + Sync + 'static,
+    T: ParamsFieldless<Spec = ParamsSpecFieldless<T>>
+        + Clone
+        + Debug
+        + Serialize
+        + Send
+        + Sync
+        + 'static,
     T::Partial: From<T>,
     T: TryFrom<T::Partial>,
 {

--- a/crate/params/src/params_spec_fieldless.rs
+++ b/crate/params/src/params_spec_fieldless.rs
@@ -196,4 +196,11 @@ where
             .map(T::try_from)
             .map(Result::ok)
     }
+
+    fn is_usable(&self) -> bool {
+        match self {
+            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
+        }
+    }
 }

--- a/crate/params/src/params_spec_fieldless.rs
+++ b/crate/params/src/params_spec_fieldless.rs
@@ -96,7 +96,7 @@ where
             Self::Stored => f.write_str("Stored"),
             Self::Value { value } => f.debug_tuple("Value").field(value).finish(),
             Self::InMemory => f.write_str("From"),
-            Self::MappingFn(_) => f.debug_tuple("MappingFn").field(&"..").finish(),
+            Self::MappingFn(mapping_fn) => f.debug_tuple("MappingFn").field(mapping_fn).finish(),
         }
     }
 }

--- a/crate/params/src/params_spec_fieldless.rs
+++ b/crate/params/src/params_spec_fieldless.rs
@@ -4,7 +4,7 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, AnySpecRtBoxed, MappingFn, MappingFnImpl, ParamsFieldless, ParamsResolveError,
+    AnySpecDataType, AnySpecRt, MappingFn, MappingFnImpl, ParamsFieldless, ParamsResolveError,
     ValueResolutionCtx, ValueSpecRt,
 };
 
@@ -189,7 +189,7 @@ where
         }
     }
 
-    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    fn merge(&mut self, other_boxed: &dyn AnySpecDataType)
     where
         Self: Sized,
     {

--- a/crate/params/src/params_specs.rs
+++ b/crate/params/src/params_specs.rs
@@ -1,11 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
 use peace_core::ItemSpecId;
-use peace_resources::type_reg::untagged::{BoxDt, TypeMap};
+use peace_resources::type_reg::untagged::TypeMap;
 use serde::Serialize;
 
-/// Map of item spec ID to its params' specs. `TypeMap<ItemSpecId, BoxDt>`
-/// newtype.
+use crate::AnySpecRtBoxed;
+
+/// Map of item spec ID to its params' specs. `TypeMap<ItemSpecId,
+/// AnySpecRtBoxed>` newtype.
 ///
 /// The concrete `*ValueSpec` type can be obtained by calling
 /// `.get(item_spec_id)` with the correct type:
@@ -24,7 +26,7 @@ use serde::Serialize;
 /// different in what they are doing.
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(transparent)] // Needed to serialize as a map instead of a list.
-pub struct ParamsSpecs(TypeMap<ItemSpecId, BoxDt>);
+pub struct ParamsSpecs(TypeMap<ItemSpecId, AnySpecRtBoxed>);
 
 impl ParamsSpecs {
     /// Returns a new `ParamsSpecs` map.
@@ -42,13 +44,13 @@ impl ParamsSpecs {
     }
 
     /// Returns the inner map.
-    pub fn into_inner(self) -> TypeMap<ItemSpecId, BoxDt> {
+    pub fn into_inner(self) -> TypeMap<ItemSpecId, AnySpecRtBoxed> {
         self.0
     }
 }
 
 impl Deref for ParamsSpecs {
-    type Target = TypeMap<ItemSpecId, BoxDt>;
+    type Target = TypeMap<ItemSpecId, AnySpecRtBoxed>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -61,8 +63,8 @@ impl DerefMut for ParamsSpecs {
     }
 }
 
-impl From<TypeMap<ItemSpecId, BoxDt>> for ParamsSpecs {
-    fn from(type_map: TypeMap<ItemSpecId, BoxDt>) -> Self {
+impl From<TypeMap<ItemSpecId, AnySpecRtBoxed>> for ParamsSpecs {
+    fn from(type_map: TypeMap<ItemSpecId, AnySpecRtBoxed>) -> Self {
         Self(type_map)
     }
 }

--- a/crate/params/src/value_spec.rs
+++ b/crate/params/src/value_spec.rs
@@ -94,7 +94,7 @@ where
             Self::Stored => f.write_str("Stored"),
             Self::Value { value } => f.debug_tuple("Value").field(value).finish(),
             Self::InMemory => f.write_str("From"),
-            Self::MappingFn(_) => f.debug_tuple("MappingFn").field(&"..").finish(),
+            Self::MappingFn(mapping_fn) => f.debug_tuple("MappingFn").field(mapping_fn).finish(),
         }
     }
 }

--- a/crate/params/src/value_spec.rs
+++ b/crate/params/src/value_spec.rs
@@ -4,7 +4,7 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, AnySpecRtBoxed, MappingFn, MappingFnImpl, ParamsResolveError, ValueResolutionCtx,
+    AnySpecDataType, AnySpecRt, MappingFn, MappingFnImpl, ParamsResolveError, ValueResolutionCtx,
     ValueSpecRt,
 };
 
@@ -173,7 +173,7 @@ where
         }
     }
 
-    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    fn merge(&mut self, other_boxed: &dyn AnySpecDataType)
     where
         Self: Sized,
     {

--- a/crate/params/src/value_spec.rs
+++ b/crate/params/src/value_spec.rs
@@ -4,7 +4,8 @@ use peace_resources::{resources::ts::SetUp, BorrowFail, Resources};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AnySpecRt, MappingFn, MappingFnImpl, ParamsResolveError, ValueResolutionCtx, ValueSpecRt,
+    AnySpecRt, AnySpecRtBoxed, MappingFn, MappingFnImpl, ParamsResolveError, ValueResolutionCtx,
+    ValueSpecRt,
 };
 
 /// How to populate a field's value in an item spec's params.
@@ -163,7 +164,7 @@ where
 
 impl<T> AnySpecRt for ValueSpec<T>
 where
-    T: Clone + Debug + Send + Sync + 'static,
+    T: Clone + Debug + Serialize + Send + Sync + 'static,
 {
     fn is_usable(&self) -> bool {
         match self {
@@ -171,11 +172,30 @@ where
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
         }
     }
+
+    fn merge(&mut self, other_boxed: &AnySpecRtBoxed)
+    where
+        Self: Sized,
+    {
+        let other: Option<&Self> = other_boxed.downcast_ref();
+        let Some(other) = other else {
+            let self_ty_name = tynm::type_name::<Self>();
+            panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.");
+        };
+        match self {
+            // Use the spec that was previously stored
+            // (as opposed to previous value).
+            Self::Stored => *self = other.clone(),
+
+            // Use set value / no change on these variants
+            Self::Value { .. } | Self::InMemory | Self::MappingFn(_) => {}
+        }
+    }
 }
 
 impl<T> ValueSpecRt for ValueSpec<T>
 where
-    T: Clone + Debug + Send + Sync + 'static,
+    T: Clone + Debug + Serialize + Send + Sync + 'static,
 {
     type ValueType = T;
 

--- a/crate/params/src/value_spec.rs
+++ b/crate/params/src/value_spec.rs
@@ -97,6 +97,15 @@ where
     }
 }
 
+impl<T> From<T> for ValueSpec<T>
+where
+    T: Clone + Debug + Send + Sync + 'static,
+{
+    fn from(value: T) -> Self {
+        Self::Value { value }
+    }
+}
+
 impl<T> ValueSpec<T>
 where
     T: Clone + Debug + Send + Sync + 'static,
@@ -170,5 +179,12 @@ where
         value_resolution_ctx: &mut ValueResolutionCtx,
     ) -> Result<Option<T>, ParamsResolveError> {
         ValueSpec::<T>::resolve_partial(self, resources, value_resolution_ctx)
+    }
+
+    fn is_usable(&self) -> bool {
+        match self {
+            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
+        }
     }
 }

--- a/crate/params/src/value_spec.rs
+++ b/crate/params/src/value_spec.rs
@@ -168,7 +168,8 @@ where
 {
     fn is_usable(&self) -> bool {
         match self {
-            Self::Stored | Self::Value { value: _ } | Self::InMemory => true,
+            Self::Stored => false,
+            Self::Value { .. } | Self::InMemory => true,
             Self::MappingFn(mapping_fn) => mapping_fn.is_valued(),
         }
     }

--- a/crate/params/src/value_spec_rt.rs
+++ b/crate/params/src/value_spec_rt.rs
@@ -33,4 +33,11 @@ pub trait ValueSpecRt {
         resources: &Resources<SetUp>,
         value_resolution_ctx: &mut ValueResolutionCtx,
     ) -> Result<Option<Self::ValueType>, ParamsResolveError>;
+
+    /// Whether this `Spec` is usable to resolve values.
+    ///
+    /// This is only `false` for `*Spec::MappingFn`s that have been
+    /// deserialized, as mapping functions cannot be deserialized back into
+    /// logic without embedding a script interpreter or compiler.
+    fn is_usable(&self) -> bool;
 }

--- a/crate/params/src/value_spec_rt.rs
+++ b/crate/params/src/value_spec_rt.rs
@@ -2,14 +2,14 @@ use std::fmt::Debug;
 
 use peace_resources::{resources::ts::SetUp, Resources};
 
-use crate::{ParamsResolveError, ValueResolutionCtx};
+use crate::{AnySpecRt, ParamsResolveError, ValueResolutionCtx};
 
 /// Runtime logic of how to look up values for each field in this struct.
 ///
 /// This trait is automatically implemented by `#[derive(Params)]` on an
-/// `ItemSpec::Params`, as well as manual implementations for standard library
-/// types.
-pub trait ValueSpecRt {
+/// `ItemSpec::Params`, as well as in the `peace_params` crate for standard
+/// library types.
+pub trait ValueSpecRt: AnySpecRt {
     /// The original value type. `MyParamsValueSpec::ValueType` is `MyParams`.
     type ValueType: Clone + Debug + Send + Sync + 'static;
 
@@ -33,11 +33,4 @@ pub trait ValueSpecRt {
         resources: &Resources<SetUp>,
         value_resolution_ctx: &mut ValueResolutionCtx,
     ) -> Result<Option<Self::ValueType>, ParamsResolveError>;
-
-    /// Whether this `Spec` is usable to resolve values.
-    ///
-    /// This is only `false` for `*Spec::MappingFn`s that have been
-    /// deserialized, as mapping functions cannot be deserialized back into
-    /// logic without embedding a script interpreter or compiler.
-    fn is_usable(&self) -> bool;
 }

--- a/crate/params_derive/src/impl_any_spec_rt_for_field_wise.rs
+++ b/crate/params_derive/src/impl_any_spec_rt_for_field_wise.rs
@@ -1,0 +1,30 @@
+use syn::{DeriveInput, Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
+
+use crate::{spec_is_usable::is_usable_body, spec_merge::spec_merge};
+
+/// `impl AnySpecRt for ValueSpec`, so that Peace can tell if a spec is usable,
+/// and merge provided and stored params together.
+pub fn impl_any_spec_rt_for_field_wise(
+    ast: &DeriveInput,
+    generics_split: &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
+    peace_params_path: &Path,
+    params_field_wise_name: &Ident,
+) -> proc_macro2::TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics_split;
+
+    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
+    let spec_merge = spec_merge(ast, params_field_wise_name, peace_params_path);
+
+    quote! {
+        impl #impl_generics #peace_params_path::AnySpecRt
+        for #params_field_wise_name #ty_generics
+        #where_clause
+        {
+            fn is_usable(&self) -> bool {
+                #is_usable_body
+            }
+
+            #spec_merge
+        }
+    }
+}

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
@@ -4,7 +4,10 @@ use syn::{
     TypeGenerics, Variant, WhereClause,
 };
 
-use crate::util::{field_spec_ty_path, fields_deconstruct, is_phantom_data, variant_match_arm};
+use crate::{
+    spec_is_usable::is_usable_body,
+    util::{field_spec_ty_path, fields_deconstruct, is_phantom_data, variant_match_arm},
+};
 
 /// `impl FieldWiseSpecRt for ValueSpec`, so that Peace can resolve the params
 /// type as well as its values from the spec.
@@ -91,6 +94,8 @@ pub fn impl_field_wise_spec_rt_for_field_wise(
         }
     };
 
+    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
+
     quote! {
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
         for #params_field_wise_name #ty_generics
@@ -113,6 +118,10 @@ pub fn impl_field_wise_spec_rt_for_field_wise(
                 value_resolution_ctx: &mut #peace_params_path::ValueResolutionCtx,
             ) -> Result<#params_partial_name #ty_generics, #peace_params_path::ParamsResolveError> {
                 #resolve_partial_body
+            }
+
+            fn is_usable(&self) -> bool {
+                #is_usable_body
             }
         }
     }

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
@@ -97,6 +97,15 @@ pub fn impl_field_wise_spec_rt_for_field_wise(
     let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
 
     quote! {
+        impl #impl_generics #peace_params_path::AnySpecRt
+        for #params_field_wise_name #ty_generics
+        #where_clause
+        {
+            fn is_usable(&self) -> bool {
+                #is_usable_body
+            }
+        }
+
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
         for #params_field_wise_name #ty_generics
         #where_clause
@@ -118,10 +127,6 @@ pub fn impl_field_wise_spec_rt_for_field_wise(
                 value_resolution_ctx: &mut #peace_params_path::ValueResolutionCtx,
             ) -> Result<#params_partial_name #ty_generics, #peace_params_path::ParamsResolveError> {
                 #resolve_partial_body
-            }
-
-            fn is_usable(&self) -> bool {
-                #is_usable_body
             }
         }
     }

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise.rs
@@ -4,10 +4,7 @@ use syn::{
     TypeGenerics, Variant, WhereClause,
 };
 
-use crate::{
-    spec_is_usable::is_usable_body,
-    util::{field_spec_ty_path, fields_deconstruct, is_phantom_data, variant_match_arm},
-};
+use crate::util::{field_spec_ty_path, fields_deconstruct, is_phantom_data, variant_match_arm};
 
 /// `impl FieldWiseSpecRt for ValueSpec`, so that Peace can resolve the params
 /// type as well as its values from the spec.
@@ -94,18 +91,7 @@ pub fn impl_field_wise_spec_rt_for_field_wise(
         }
     };
 
-    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
-
     quote! {
-        impl #impl_generics #peace_params_path::AnySpecRt
-        for #params_field_wise_name #ty_generics
-        #where_clause
-        {
-            fn is_usable(&self) -> bool {
-                #is_usable_body
-            }
-        }
-
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
         for #params_field_wise_name #ty_generics
         #where_clause

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
@@ -18,6 +18,15 @@ pub fn impl_field_wise_spec_rt_for_field_wise_external(
     let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
 
     quote! {
+        impl #impl_generics #peace_params_path::AnySpecRt
+        for #params_field_wise_name #ty_generics
+        #where_clause
+        {
+            fn is_usable(&self) -> bool {
+                #is_usable_body
+            }
+        }
+
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
         for #params_field_wise_name #ty_generics
         #where_clause
@@ -77,10 +86,6 @@ pub fn impl_field_wise_spec_rt_for_field_wise_external(
                         },
                     }
                 }
-            }
-
-            fn is_usable(&self) -> bool {
-                #is_usable_body
             }
         }
     }

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
@@ -1,8 +1,11 @@
-use syn::{Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
+use syn::{DeriveInput, Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
+
+use crate::spec_is_usable::is_usable_body;
 
 /// `impl FieldWiseSpecRt for ValueSpec`, so that Peace can resolve the params
 /// type as well as its values from the spec.
 pub fn impl_field_wise_spec_rt_for_field_wise_external(
+    ast: &DeriveInput,
     generics_split: &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
     peace_params_path: &Path,
     peace_resources_path: &Path,
@@ -11,6 +14,8 @@ pub fn impl_field_wise_spec_rt_for_field_wise_external(
     params_partial_name: &Ident,
 ) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics_split;
+
+    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
 
     quote! {
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
@@ -72,6 +77,10 @@ pub fn impl_field_wise_spec_rt_for_field_wise_external(
                         },
                     }
                 }
+            }
+
+            fn is_usable(&self) -> bool {
+                #is_usable_body
             }
         }
     }

--- a/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
+++ b/crate/params_derive/src/impl_field_wise_spec_rt_for_field_wise_external.rs
@@ -1,11 +1,8 @@
-use syn::{DeriveInput, Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
-
-use crate::spec_is_usable::is_usable_body;
+use syn::{Ident, ImplGenerics, Path, TypeGenerics, WhereClause};
 
 /// `impl FieldWiseSpecRt for ValueSpec`, so that Peace can resolve the params
 /// type as well as its values from the spec.
 pub fn impl_field_wise_spec_rt_for_field_wise_external(
-    ast: &DeriveInput,
     generics_split: &(ImplGenerics, TypeGenerics, Option<&WhereClause>),
     peace_params_path: &Path,
     peace_resources_path: &Path,
@@ -15,18 +12,7 @@ pub fn impl_field_wise_spec_rt_for_field_wise_external(
 ) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics_split;
 
-    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
-
     quote! {
-        impl #impl_generics #peace_params_path::AnySpecRt
-        for #params_field_wise_name #ty_generics
-        #where_clause
-        {
-            fn is_usable(&self) -> bool {
-                #is_usable_body
-            }
-        }
-
         impl #impl_generics #peace_params_path::FieldWiseSpecRt
         for #params_field_wise_name #ty_generics
         #where_clause

--- a/crate/params_derive/src/impl_value_spec_rt_for_field_wise.rs
+++ b/crate/params_derive/src/impl_value_spec_rt_for_field_wise.rs
@@ -4,10 +4,7 @@ use syn::{
     TypeGenerics, Variant, WhereClause,
 };
 
-use crate::{
-    spec_is_usable::is_usable_body,
-    util::{field_spec_ty, fields_deconstruct, is_phantom_data, variant_match_arm},
-};
+use crate::util::{field_spec_ty, fields_deconstruct, is_phantom_data, variant_match_arm};
 
 /// `impl ValueSpecRt for ValueSpec`, so that Peace can resolve the params type
 /// as well as its values from the spec.
@@ -93,8 +90,6 @@ pub fn impl_value_spec_rt_for_field_wise(
         }
     };
 
-    let is_usable_body = is_usable_body(ast, params_field_wise_name, peace_params_path);
-
     quote! {
         impl #impl_generics #peace_params_path::ValueSpecRt
         for #params_field_wise_name #ty_generics
@@ -116,10 +111,6 @@ pub fn impl_value_spec_rt_for_field_wise(
                 value_resolution_ctx: &mut #peace_params_path::ValueResolutionCtx,
             ) -> Result<Option<#params_name #ty_generics>, #peace_params_path::ParamsResolveError> {
                 #try_resolve_body
-            }
-
-            fn is_usable(&self) -> bool {
-                #is_usable_body
             }
         }
     }

--- a/crate/params_derive/src/lib.rs
+++ b/crate/params_derive/src/lib.rs
@@ -41,6 +41,7 @@ mod impl_from_params_for_params_field_wise;
 mod impl_from_params_for_params_partial;
 mod impl_try_from_params_partial_for_params;
 mod impl_value_spec_rt_for_field_wise;
+mod spec_is_usable;
 mod type_gen;
 mod type_gen_external;
 mod util;
@@ -518,6 +519,7 @@ fn t_field_wise_external(
     );
 
     t_field_wise.extend(impl_field_wise_spec_rt_for_field_wise_external(
+        ast,
         generics_split,
         peace_params_path,
         peace_resources_path,
@@ -525,16 +527,6 @@ fn t_field_wise_external(
         t_field_wise_name,
         t_partial_name,
     ));
-
-    // TODO: Do we need this?
-    // t_field_wise.extend(impl_value_spec_rt_for_field_wise_external(
-    //     ast,
-    //     generics_split,
-    //     peace_params_path,
-    //     peace_resources_path,
-    //     params_name,
-    //     t_field_wise_name,
-    // ));
 
     t_field_wise
 }

--- a/crate/params_derive/src/lib.rs
+++ b/crate/params_derive/src/lib.rs
@@ -18,6 +18,7 @@ use syn::{
 use crate::{
     field_wise_enum_builder_ctx::FieldWiseEnumBuilderCtx,
     fields_map::{fields_to_optional, fields_to_value_spec},
+    impl_any_spec_rt_for_field_wise::impl_any_spec_rt_for_field_wise,
     impl_default::impl_default,
     impl_field_wise_builder::impl_field_wise_builder,
     impl_field_wise_spec_rt_for_field_wise::impl_field_wise_spec_rt_for_field_wise,
@@ -33,6 +34,7 @@ use crate::{
 
 mod field_wise_enum_builder_ctx;
 mod fields_map;
+mod impl_any_spec_rt_for_field_wise;
 mod impl_default;
 mod impl_field_wise_builder;
 mod impl_field_wise_spec_rt_for_field_wise;
@@ -42,6 +44,7 @@ mod impl_from_params_for_params_partial;
 mod impl_try_from_params_partial_for_params;
 mod impl_value_spec_rt_for_field_wise;
 mod spec_is_usable;
+mod spec_merge;
 mod type_gen;
 mod type_gen_external;
 mod util;
@@ -485,6 +488,13 @@ fn t_field_wise(
         t_field_wise_name,
     ));
 
+    t_field_wise.extend(impl_any_spec_rt_for_field_wise(
+        ast,
+        generics_split,
+        peace_params_path,
+        t_field_wise_name,
+    ));
+
     t_field_wise
 }
 
@@ -519,13 +529,19 @@ fn t_field_wise_external(
     );
 
     t_field_wise.extend(impl_field_wise_spec_rt_for_field_wise_external(
-        ast,
         generics_split,
         peace_params_path,
         peace_resources_path,
         params_name,
         t_field_wise_name,
         t_partial_name,
+    ));
+
+    t_field_wise.extend(impl_any_spec_rt_for_field_wise(
+        ast,
+        generics_split,
+        peace_params_path,
+        t_field_wise_name,
     ));
 
     t_field_wise

--- a/crate/params_derive/src/spec_is_usable.rs
+++ b/crate/params_derive/src/spec_is_usable.rs
@@ -1,0 +1,172 @@
+use syn::{punctuated::Punctuated, DeriveInput, Fields, Ident, Path, Variant};
+
+use crate::util::{fields_deconstruct, fields_stmt_map, variant_match_arm};
+
+pub fn is_usable_body(
+    ast: &DeriveInput,
+    params_field_wise_name: &Ident,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    match &ast.data {
+        syn::Data::Struct(data_struct) => {
+            let fields = &data_struct.fields;
+
+            struct_fields_is_usable(params_field_wise_name, fields, peace_params_path)
+        }
+        syn::Data::Enum(data_enum) => {
+            let variants = &data_enum.variants;
+
+            variants_is_usable(params_field_wise_name, variants, peace_params_path)
+        }
+        syn::Data::Union(data_union) => {
+            let fields = Fields::from(data_union.fields.clone());
+
+            struct_fields_is_usable(params_field_wise_name, &fields, peace_params_path)
+        }
+    }
+}
+
+/// Returns whether the fields within this struct all return `true` for
+/// `is_usable`.
+pub fn struct_fields_is_usable(
+    params_field_wise_name: &Ident,
+    fields: &Fields,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    let fields_is_usable = fields_is_usable(fields, peace_params_path);
+    let fields_deconstructed = fields_deconstruct(fields);
+
+    match fields {
+        Fields::Named(_fields_named) => {
+            // Generates:
+            //
+            // ```rust
+            // let #params_field_wise_name {
+            //     field_1,
+            //     field_2,
+            //     marker: PhantomData,
+            // } = self;
+            //
+            // let mut is_usable = true;
+            // is_usable &= ValueSpecRt::is_usable(field_1);
+            // is_usable &= ValueSpecRt::is_usable(field_2);
+            //
+            // is_usable
+            // ```
+
+            quote! {
+                let #params_field_wise_name {
+                    #(#fields_deconstructed),*
+                } = self;
+
+                let mut is_usable = true;
+                #fields_is_usable
+
+                is_usable
+            }
+        }
+        Fields::Unnamed(_fields_unnamed) => {
+            // Generates:
+            //
+            // ```rust
+            // let #params_name(_0, _1, PhantomData,) = self;
+            //
+            // let mut is_usable = true;
+            // is_usable &= ValueSpecRt::is_usable(_0);
+            // is_usable &= ValueSpecRt::is_usable(_1);
+            //
+            // is_usable
+            // ```
+
+            quote! {
+                let #params_field_wise_name(#(#fields_deconstructed),*) = self;
+
+                let mut is_usable = true;
+                #fields_is_usable
+
+                is_usable
+            }
+        }
+        Fields::Unit => quote!(true),
+    }
+}
+
+/// Returns whether the fields within this enum all return `true` for
+/// `is_usable`.
+pub fn variants_is_usable(
+    params_field_wise_name: &Ident,
+    variants: &Punctuated<Variant, Token![,]>,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    // Generates:
+    //
+    // ```rust
+    // match self {
+    //     ValueSpec::Variant1 => true,
+    //     ValueSpec::Variant2(_0, _1, PhantomData) => {
+    //         let mut is_usable = true;
+    //         is_usable &= ValueSpecRt::is_usable(_0);
+    //         is_usable &= ValueSpecRt::is_usable(_1);
+    //         is_usable
+    //     }
+    //     ValueSpec::Variant3 {
+    //         field_1,
+    //         field_2,
+    //         marker: PhantomData,
+    //     } => {
+    //         let mut is_usable = true;
+    //         is_usable &= ValueSpecRt::is_usable(field_1);
+    //         is_usable &= ValueSpecRt::is_usable(field_2);
+    //         is_usable
+    //     }
+    // }
+    // ```
+
+    let variant_resolve_arms =
+        variants
+            .iter()
+            .fold(proc_macro2::TokenStream::new(), |mut tokens, variant| {
+                let fields = &variant.fields;
+                let fields_deconstructed = fields_deconstruct(fields);
+
+                let variant_fields_is_usable = {
+                    let fields_is_usable = fields_is_usable(fields, peace_params_path);
+
+                    quote! {
+                        let mut is_usable = true;
+                        #fields_is_usable
+
+                        is_usable
+                    }
+                };
+                tokens.extend(variant_match_arm(
+                    params_field_wise_name,
+                    variant,
+                    &fields_deconstructed,
+                    variant_fields_is_usable,
+                ));
+
+                tokens
+            });
+
+    quote! {
+        match self {
+            #variant_resolve_arms
+        }
+    }
+}
+
+fn fields_is_usable(fields: &Fields, peace_params_path: &Path) -> proc_macro2::TokenStream {
+    fields_stmt_map(fields, move |_field, field_name, _field_index| {
+        quote! {
+            is_usable &= #peace_params_path::ValueSpecRt::is_usable(#field_name);
+        }
+    })
+    .fold(
+        proc_macro2::TokenStream::new(),
+        |mut tokens, next_tokens| {
+            tokens.extend(next_tokens);
+            tokens
+        },
+    )
+}

--- a/crate/params_derive/src/spec_is_usable.rs
+++ b/crate/params_derive/src/spec_is_usable.rs
@@ -48,8 +48,8 @@ pub fn struct_fields_is_usable(
             // } = self;
             //
             // let mut is_usable = true;
-            // is_usable &= ValueSpecRt::is_usable(field_1);
-            // is_usable &= ValueSpecRt::is_usable(field_2);
+            // is_usable &= AnySpecRt::is_usable(field_1);
+            // is_usable &= AnySpecRt::is_usable(field_2);
             //
             // is_usable
             // ```
@@ -72,8 +72,8 @@ pub fn struct_fields_is_usable(
             // let #params_name(_0, _1, PhantomData,) = self;
             //
             // let mut is_usable = true;
-            // is_usable &= ValueSpecRt::is_usable(_0);
-            // is_usable &= ValueSpecRt::is_usable(_1);
+            // is_usable &= AnySpecRt::is_usable(_0);
+            // is_usable &= AnySpecRt::is_usable(_1);
             //
             // is_usable
             // ```
@@ -105,8 +105,8 @@ pub fn variants_is_usable(
     //     ValueSpec::Variant1 => true,
     //     ValueSpec::Variant2(_0, _1, PhantomData) => {
     //         let mut is_usable = true;
-    //         is_usable &= ValueSpecRt::is_usable(_0);
-    //         is_usable &= ValueSpecRt::is_usable(_1);
+    //         is_usable &= AnySpecRt::is_usable(_0);
+    //         is_usable &= AnySpecRt::is_usable(_1);
     //         is_usable
     //     }
     //     ValueSpec::Variant3 {
@@ -115,8 +115,8 @@ pub fn variants_is_usable(
     //         marker: PhantomData,
     //     } => {
     //         let mut is_usable = true;
-    //         is_usable &= ValueSpecRt::is_usable(field_1);
-    //         is_usable &= ValueSpecRt::is_usable(field_2);
+    //         is_usable &= AnySpecRt::is_usable(field_1);
+    //         is_usable &= AnySpecRt::is_usable(field_2);
     //         is_usable
     //     }
     // }
@@ -159,7 +159,7 @@ pub fn variants_is_usable(
 fn fields_is_usable(fields: &Fields, peace_params_path: &Path) -> proc_macro2::TokenStream {
     fields_stmt_map(fields, move |_field, field_name, _field_index| {
         quote! {
-            is_usable &= #peace_params_path::ValueSpecRt::is_usable(#field_name);
+            is_usable &= #peace_params_path::AnySpecRt::is_usable(#field_name);
         }
     })
     .fold(

--- a/crate/params_derive/src/spec_merge.rs
+++ b/crate/params_derive/src/spec_merge.rs
@@ -35,7 +35,17 @@ pub fn spec_merge(
             let other: Option<&Self> = other_boxed.downcast_ref();
             let Some(other) = other else {
                 let self_ty_name = #peace_params_path::tynm::type_name::<Self>();
-                panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.");
+
+                // Args need to be manually specified because Rust 1.69.0 does not allow
+                // capturing args from scope within generated macro.
+                //
+                // ```ignore
+                // to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
+                // ```
+                panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.",
+                    self_ty_name = self_ty_name,
+                    other_boxed = other_boxed,
+                );
             };
 
             #merge_logic

--- a/crate/params_derive/src/spec_merge.rs
+++ b/crate/params_derive/src/spec_merge.rs
@@ -1,0 +1,187 @@
+use syn::{punctuated::Punctuated, DeriveInput, Fields, Ident, Path, Variant};
+
+use crate::util::{
+    fields_deconstruct, fields_deconstruct_rename_other, fields_stmt_map, variant_match_arm,
+};
+
+pub fn spec_merge(
+    ast: &DeriveInput,
+    params_field_wise_name: &Ident,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    let merge_logic = match &ast.data {
+        syn::Data::Struct(data_struct) => {
+            let fields = &data_struct.fields;
+
+            struct_fields_spec_merge(params_field_wise_name, fields, peace_params_path)
+        }
+        syn::Data::Enum(data_enum) => {
+            let variants = &data_enum.variants;
+
+            variants_spec_merge(params_field_wise_name, variants, peace_params_path)
+        }
+        syn::Data::Union(data_union) => {
+            let fields = Fields::from(data_union.fields.clone());
+
+            struct_fields_spec_merge(params_field_wise_name, &fields, peace_params_path)
+        }
+    };
+
+    quote! {
+        fn merge(&mut self, other_boxed: &#peace_params_path::AnySpecRtBoxed)
+        where
+            Self: Sized,
+        {
+            let other: Option<&Self> = other_boxed.downcast_ref();
+            let Some(other) = other else {
+                let self_ty_name = tynm::type_name::<Self>();
+                panic!("Failed to downcast value into `{self_ty_name}`. Value: `{other_boxed:#?}`.");
+            };
+
+            #merge_logic
+        }
+    }
+}
+
+/// Deep merges spec fields within this struct.
+pub fn struct_fields_spec_merge(
+    params_field_wise_name: &Ident,
+    fields: &Fields,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    let fields_spec_merge = fields_spec_merge(fields, peace_params_path);
+    let fields_deconstructed = fields_deconstruct(fields);
+    let fields_deconstructed_other = fields_deconstruct_rename_other(fields);
+
+    match fields {
+        Fields::Named(_fields_named) => {
+            // Generates:
+            //
+            // ```rust
+            // let #params_field_wise_name {
+            //     field_1,
+            //     field_2,
+            //     marker: PhantomData,
+            // } = self;
+            //
+            // let #params_field_wise_name {
+            //     field_1: field_1_other,
+            //     field_2: field_2_other,
+            //     marker: PhantomData,
+            // } = other;
+            //
+            // AnySpecRt::merge(field_1, field_1_other);
+            // AnySpecRt::merge(field_2, field_2_other);
+            // ```
+
+            quote! {
+                let #params_field_wise_name {
+                    #(#fields_deconstructed),*
+                } = self;
+
+                let #params_field_wise_name {
+                    #(#fields_deconstructed_other),*
+                } = other;
+
+                #fields_spec_merge
+            }
+        }
+        Fields::Unnamed(_fields_unnamed) => {
+            // Generates:
+            //
+            // ```rust
+            // let #params_name(_0, _1, PhantomData,) = self;
+            // let #params_name(_0_other, _1_other, PhantomData,) = other;
+            //
+            // AnySpecRt::merge(_0, _0_other);
+            // AnySpecRt::merge(_1, _1_other);
+            // ```
+
+            quote! {
+                let #params_field_wise_name(#(#fields_deconstructed),*) = self;
+                let #params_field_wise_name(#(#fields_deconstructed_other),*) = other;
+
+                #fields_spec_merge
+
+                spec_merge
+            }
+        }
+        Fields::Unit => quote!(),
+    }
+}
+
+/// Deep merges spec fields within this enum.
+pub fn variants_spec_merge(
+    params_field_wise_name: &Ident,
+    variants: &Punctuated<Variant, Token![,]>,
+    peace_params_path: &Path,
+) -> proc_macro2::TokenStream {
+    // Generates:
+    //
+    // ```rust
+    // match self {
+    //     ValueSpec::Variant1 => true,
+    //     ValueSpec::Variant2(_0, _1, PhantomData) => {
+    //         AnySpecRt::merge(_0, _0_other);
+    //         AnySpecRt::merge(_1, _1_other);
+    //     }
+    //     ValueSpec::Variant3 {
+    //         field_1,
+    //         field_2,
+    //         marker: PhantomData,
+    //     } => {
+    //         AnySpecRt::merge(field_1, field_1_other);
+    //         AnySpecRt::merge(field_2, field_2_other);
+    //     }
+    // }
+    // ```
+
+    let variant_resolve_arms =
+        variants
+            .iter()
+            .fold(proc_macro2::TokenStream::new(), |mut tokens, variant| {
+                let fields = &variant.fields;
+                let fields_deconstructed = fields_deconstruct(fields);
+
+                let variant_fields_spec_merge = {
+                    let fields_spec_merge = fields_spec_merge(fields, peace_params_path);
+
+                    quote! {
+                        let mut spec_merge = true;
+                        #fields_spec_merge
+
+                        spec_merge
+                    }
+                };
+                tokens.extend(variant_match_arm(
+                    params_field_wise_name,
+                    variant,
+                    &fields_deconstructed,
+                    variant_fields_spec_merge,
+                ));
+
+                tokens
+            });
+
+    quote! {
+        match self {
+            #variant_resolve_arms
+        }
+    }
+}
+
+fn fields_spec_merge(fields: &Fields, peace_params_path: &Path) -> proc_macro2::TokenStream {
+    fields_stmt_map(fields, move |_field, field_name, _field_index| {
+        let field_name_other = format_ident!("{}_other", field_name);
+        quote! {
+            #peace_params_path::AnySpecRt::merge(#field_name, #field_name_other);
+        }
+    })
+    .fold(
+        proc_macro2::TokenStream::new(),
+        |mut tokens, next_tokens| {
+            tokens.extend(next_tokens);
+            tokens
+        },
+    )
+}

--- a/crate/params_derive/src/util.rs
+++ b/crate/params_derive/src/util.rs
@@ -284,6 +284,22 @@ pub fn fields_deconstruct_none(fields: &Fields) -> Vec<proc_macro2::TokenStream>
     fields_deconstruct_retain_map(fields, false, Some(|_field_name| quote!(None)))
 }
 
+/// Returns a comma separated list of deconstructed fields, deconstructed as
+/// `field: field_other`.
+///
+/// Tuple fields are returned as `_n_other`, and marker fields are returned as
+/// `::std::marker::PhantomData`.
+pub fn fields_deconstruct_rename_other(fields: &Fields) -> Vec<proc_macro2::TokenStream> {
+    fields_deconstruct_retain_map(
+        fields,
+        false,
+        Some(|field_name| {
+            let field_name_other = format_ident!("{}_other", field_name);
+            quote!(#field_name_other)
+        }),
+    )
+}
+
 pub fn fields_deconstruct_retain(
     fields: &Fields,
     retain_phantom_data: bool,

--- a/crate/rt_model/src/params_specs_type_reg.rs
+++ b/crate/rt_model/src/params_specs_type_reg.rs
@@ -1,20 +1,22 @@
 use std::ops::{Deref, DerefMut};
 
 use peace_cfg::ItemSpecId;
-use peace_resources::type_reg::untagged::{BoxDt, TypeReg};
+use peace_params::AnySpecRtBoxed;
+use peace_resources::type_reg::untagged::TypeReg;
 
 /// Type registry for each item spec's [`Params`]'s Spec.
 ///
 /// This is used to deserialize [`ParamsSpecsFile`].
 ///
-/// Note: [`StatesTypeReg`] uses [`BoxDtDisplay`], whereas this uses [`BoxDt`].
+/// Note: [`StatesTypeReg`] uses [`BoxDtDisplay`], whereas this uses
+/// [`AnySpecRtBoxed`].
 ///
-/// [`BoxDt`]: peace_resources::type_reg::untagged::BoxDt
+/// [`AnySpecRtBoxed`]: peace_params::AnySpecRtBoxed
 /// [`BoxDtDisplay`]: peace_resources::type_reg::untagged::BoxDtDisplay
 /// [`Params`]: peace_cfg::ItemSpec::Params
 /// [`StatesTypeReg`]: crate::StatesTypeReg
 #[derive(Debug, Default)]
-pub struct ParamsSpecsTypeReg(TypeReg<ItemSpecId, BoxDt>);
+pub struct ParamsSpecsTypeReg(TypeReg<ItemSpecId, AnySpecRtBoxed>);
 
 impl ParamsSpecsTypeReg {
     /// Returns a new `ParamsSpecsTypeReg`.
@@ -24,7 +26,7 @@ impl ParamsSpecsTypeReg {
 }
 
 impl Deref for ParamsSpecsTypeReg {
-    type Target = TypeReg<ItemSpecId, BoxDt>;
+    type Target = TypeReg<ItemSpecId, AnySpecRtBoxed>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crate/rt_model_core/src/error.rs
+++ b/crate/rt_model_core/src/error.rs
@@ -111,7 +111,7 @@ pub enum Error {
                 item_spec_ids_with_no_params_specs,
                 params_specs_provided_mismatches,
                 params_specs_stored_mismatches.as_ref(),
-                spec_not_provided_for_previously_stored_mapping_fn,
+                params_specs_not_usable,
             ))
         )
     )]
@@ -125,7 +125,7 @@ pub enum Error {
         /// Item spec IDs which had a mapping function previously provided in
         /// its params spec, but on a subsequent invocation nothing was
         /// provided.
-        spec_not_provided_for_previously_stored_mapping_fn: Vec<ItemSpecId>,
+        params_specs_not_usable: Vec<ItemSpecId>,
     },
 
     /// In a `MultiProfileSingleFlow` diff, neither profile had `Params::Specs`
@@ -571,7 +571,7 @@ fn params_specs_mismatch_display(
     item_spec_ids_with_no_params: &[ItemSpecId],
     params_specs_provided_mismatches: &ParamsSpecs,
     params_specs_stored_mismatches: Option<&ParamsSpecs>,
-    spec_not_provided_for_previously_stored_mapping_fn: &[ItemSpecId],
+    params_specs_not_usable: &[ItemSpecId],
 ) -> String {
     let mut items = Vec::<String>::new();
 
@@ -616,13 +616,14 @@ fn params_specs_mismatch_display(
         }
     }
 
-    if !spec_not_provided_for_previously_stored_mapping_fn.is_empty() {
+    if !params_specs_not_usable.is_empty() {
         items.push(format!(
-            "The following item specs had a mapping function in its previous execution,\n\
-            and subsequent execution requires a spec:\n\
+            "The following item specs either have not had a params spec provided previously,\n\
+            or previously had a mapping function provided which cannot be automatically loaded.\n\
+            So the current execution requires the spec to be provided:\n\
             \n\
             {}\n",
-            spec_not_provided_for_previously_stored_mapping_fn
+            params_specs_not_usable
                 .iter()
                 .map(|item_spec_id| format!("* {item_spec_id}"))
                 .collect::<Vec<String>>()

--- a/crate/rt_model_core/src/error.rs
+++ b/crate/rt_model_core/src/error.rs
@@ -111,6 +111,7 @@ pub enum Error {
                 item_spec_ids_with_no_params_specs,
                 params_specs_provided_mismatches,
                 params_specs_stored_mismatches.as_ref(),
+                spec_not_provided_for_previously_stored_mapping_fn,
             ))
         )
     )]
@@ -121,6 +122,10 @@ pub enum Error {
         params_specs_provided_mismatches: ParamsSpecs,
         /// Stored params specs with no matching item spec ID in the flow.
         params_specs_stored_mismatches: Option<ParamsSpecs>,
+        /// Item spec IDs which had a mapping function previously provided in
+        /// its params spec, but on a subsequent invocation nothing was
+        /// provided.
+        spec_not_provided_for_previously_stored_mapping_fn: Vec<ItemSpecId>,
     },
 
     /// In a `MultiProfileSingleFlow` diff, neither profile had `Params::Specs`
@@ -566,6 +571,7 @@ fn params_specs_mismatch_display(
     item_spec_ids_with_no_params: &[ItemSpecId],
     params_specs_provided_mismatches: &ParamsSpecs,
     params_specs_stored_mismatches: Option<&ParamsSpecs>,
+    spec_not_provided_for_previously_stored_mapping_fn: &[ItemSpecId],
 ) -> String {
     let mut items = Vec::<String>::new();
 
@@ -608,6 +614,20 @@ fn params_specs_mismatch_display(
                 {params_specs_stored_mismatches_list}\n",
             ));
         }
+    }
+
+    if !spec_not_provided_for_previously_stored_mapping_fn.is_empty() {
+        items.push(format!(
+            "The following item specs had a mapping function in its previous execution,\n\
+            and subsequent execution requires a spec:\n\
+            \n\
+            {}\n",
+            spec_not_provided_for_previously_stored_mapping_fn
+                .iter()
+                .map(|item_spec_id| format!("* {item_spec_id}"))
+                .collect::<Vec<String>>()
+                .join("\n")
+        ));
     }
 
     items.join("\n")

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
@@ -471,13 +471,13 @@ async fn build_with_item_spec_params_returns_err_when_params_not_provided_and_no
                     item_spec_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
                     params_specs_stored_mismatches,
-                    spec_not_provided_for_previously_stored_mapping_fn,
+                    params_specs_not_usable,
                 }
             ))
             if item_spec_ids_with_no_params_specs == &vec![VecCopyItemSpec::ID_DEFAULT.clone()]
             && params_specs_provided_mismatches.is_empty()
             && params_specs_stored_mismatches.is_none()
-            && spec_not_provided_for_previously_stored_mapping_fn.is_empty(),
+            && params_specs_not_usable.is_empty(),
         ),
         "was {cmd_ctx_result:#?}"
     );
@@ -644,7 +644,7 @@ async fn build_with_item_spec_params_returns_err_when_params_provided_mismatch()
                     item_spec_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
                     params_specs_stored_mismatches,
-                    spec_not_provided_for_previously_stored_mapping_fn,
+                    params_specs_not_usable,
                 }
             ))
             if item_spec_ids_with_no_params_specs.is_empty()
@@ -658,7 +658,7 @@ async fn build_with_item_spec_params_returns_err_when_params_provided_mismatch()
                 Some(params_specs_stored_mismatches)
                 if params_specs_stored_mismatches.is_empty()
             )
-            && spec_not_provided_for_previously_stored_mapping_fn.is_empty(),
+            && params_specs_not_usable.is_empty(),
         ),
         "was {cmd_ctx_result:#?}"
     );
@@ -719,7 +719,7 @@ async fn build_with_item_spec_params_returns_err_when_params_stored_mismatch()
                     item_spec_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
                     params_specs_stored_mismatches,
-                    spec_not_provided_for_previously_stored_mapping_fn,
+                    params_specs_not_usable,
                 }
             ))
             if item_spec_ids_with_no_params_specs == &vec![item_spec_id!("new_id")]
@@ -733,7 +733,7 @@ async fn build_with_item_spec_params_returns_err_when_params_stored_mismatch()
                 Some(params_specs_stored_mismatches)
                 if params_specs_stored_mismatches.is_empty()
             )
-            && spec_not_provided_for_previously_stored_mapping_fn.is_empty(),
+            && params_specs_not_usable.is_empty(),
         ),
         "was {cmd_ctx_result:#?}"
     );
@@ -869,7 +869,7 @@ async fn build_with_item_spec_params_returns_err_when_spec_fully_not_provided_fo
                     item_spec_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
                     params_specs_stored_mismatches,
-                    spec_not_provided_for_previously_stored_mapping_fn,
+                    params_specs_not_usable,
                 }
             ))
             if item_spec_ids_with_no_params_specs.is_empty()
@@ -879,7 +879,7 @@ async fn build_with_item_spec_params_returns_err_when_spec_fully_not_provided_fo
                 Some(params_specs_stored_mismatches)
                 if params_specs_stored_mismatches.is_empty()
             )
-            && spec_not_provided_for_previously_stored_mapping_fn == &[VecCopyItemSpec::ID_DEFAULT.clone()],
+            && params_specs_not_usable == &[VecCopyItemSpec::ID_DEFAULT.clone()],
         ),
         "was {cmd_ctx_result:#?}"
     );
@@ -941,7 +941,7 @@ async fn build_with_item_spec_params_returns_err_when_value_spec_not_provided_fo
                     item_spec_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
                     params_specs_stored_mismatches,
-                    spec_not_provided_for_previously_stored_mapping_fn,
+                    params_specs_not_usable,
                 }
             ))
             if item_spec_ids_with_no_params_specs.is_empty()
@@ -951,7 +951,7 @@ async fn build_with_item_spec_params_returns_err_when_value_spec_not_provided_fo
                 Some(params_specs_stored_mismatches)
                 if params_specs_stored_mismatches.is_empty()
             )
-            && spec_not_provided_for_previously_stored_mapping_fn == &[VecCopyItemSpec::ID_DEFAULT.clone()],
+            && params_specs_not_usable == &[VecCopyItemSpec::ID_DEFAULT.clone()],
         ),
         "was {cmd_ctx_result:#?}"
     );

--- a/workspace_tests/src/params.rs
+++ b/workspace_tests/src/params.rs
@@ -2,3 +2,4 @@ mod derive;
 mod mapping_fn_impl;
 mod params_spec;
 mod params_spec_fieldless;
+mod value_spec;

--- a/workspace_tests/src/params/derive.rs
+++ b/workspace_tests/src/params/derive.rs
@@ -1901,12 +1901,12 @@ mod enum_recursive_value {
 
     use serde::{Deserialize, Serialize};
 
-    use peace::params::{Params, ParamsFieldless, ParamsSpec, ParamsSpecFieldless, ValueSpec};
+    use peace::params::{Params, ParamsSpec, ValueSpec};
 
-    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ParamsFieldless)]
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
     pub enum InnerValue<T>
     where
-        T: Clone + Debug + ParamsFieldless,
+        T: Clone + Debug,
     {
         Tuple(T),
         Named { value: T },
@@ -1915,14 +1915,7 @@ mod enum_recursive_value {
     #[derive(Clone, Debug, Params, PartialEq, Eq, Serialize, Deserialize)]
     pub enum EnumRecursiveValue<T>
     where
-        T: Clone
-            + Debug
-            + ParamsFieldless<Spec = ParamsSpecFieldless<T>>
-            + TryFrom<<T as ParamsFieldless>::Partial>
-            + Send
-            + Sync
-            + 'static,
-        T::Partial: From<T>,
+        T: Clone + Debug + Send + Sync + 'static,
     {
         Tuple(InnerValue<T>, u32),
         Named { src: InnerValue<T>, dest: u32 },

--- a/workspace_tests/src/params/params_spec.rs
+++ b/workspace_tests/src/params/params_spec.rs
@@ -1,8 +1,8 @@
 use peace::{
     cfg::{item_spec_id, ItemSpecId},
     params::{
-        FieldWiseSpecRt, Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec,
-        ValueSpecRt,
+        AnySpecRt, FieldWiseSpecRt, Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode,
+        ValueSpec,
     },
     resources::{resources::ts::SetUp, Resources},
 };

--- a/workspace_tests/src/params/params_spec.rs
+++ b/workspace_tests/src/params/params_spec.rs
@@ -273,8 +273,12 @@ field_wise_spec: !MappingFn
 }
 
 #[test]
-fn is_usable_returns_true_for_stored_value_in_memory() {
-    assert!(ParamsSpec::<VecA>::Stored.is_usable());
+fn is_usable_returns_false_for_stored() {
+    assert!(!ParamsSpec::<VecA>::Stored.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_for_value_and_in_memory() {
     assert!(
         ParamsSpec::<VecA>::Value {
             value: VecA::default()

--- a/workspace_tests/src/params/params_spec.rs
+++ b/workspace_tests/src/params/params_spec.rs
@@ -2,6 +2,7 @@ use peace::{
     cfg::{item_spec_id, ItemSpecId},
     params::{
         FieldWiseSpecRt, Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec,
+        ValueSpecRt,
     },
     resources::{resources::ts::SetUp, Resources},
 };
@@ -216,7 +217,7 @@ field_wise_spec: !Value
                     })
             }
             if value == &[1u8]
-            && field_wise_spec.resolve(&resources, &mut value_resolution_ctx)?
+            && FieldWiseSpecRt::resolve(field_wise_spec, &resources, &mut value_resolution_ctx)?
             == VecA(vec![1u8])
         ),
         "was {deserialized:?}"
@@ -268,5 +269,63 @@ field_wise_spec: !MappingFn
         "was {deserialized:?}"
     );
 
+    Ok(())
+}
+
+#[test]
+fn is_usable_returns_true_for_stored_value_in_memory() {
+    assert!(ParamsSpec::<VecA>::Stored.is_usable());
+    assert!(
+        ParamsSpec::<VecA>::Value {
+            value: VecA::default()
+        }
+        .is_usable()
+    );
+    assert!(ParamsSpec::<VecA>::InMemory.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_when_mapping_fn_is_some() {
+    assert!(ParamsSpec::<VecA>::from_map(None, |_: &u8| None).is_usable());
+}
+
+#[test]
+fn is_usable_returns_false_when_mapping_fn_is_none() -> Result<(), serde_yaml::Error> {
+    let params_spec: ParamsSpec<VecA> = serde_yaml::from_str(
+        r#"!MappingFn
+field_name: null
+fn_map: Some(Fn(&bool, &u16) -> Option<Vec<u8>>)
+marker: null
+"#,
+    )?;
+
+    assert!(!params_spec.is_usable());
+    Ok(())
+}
+
+#[test]
+fn is_usable_returns_true_when_field_wise_is_usable() -> Result<(), serde_yaml::Error> {
+    let params_spec: ParamsSpec<VecA> = serde_yaml::from_str(
+        r#"!FieldWise
+field_wise_spec: InMemory
+"#,
+    )?;
+
+    assert!(params_spec.is_usable());
+    Ok(())
+}
+
+#[test]
+fn is_usable_returns_false_when_field_wise_is_not_usable() -> Result<(), serde_yaml::Error> {
+    let params_spec: ParamsSpec<VecA> = serde_yaml::from_str(
+        r#"!FieldWise
+field_wise_spec: !MappingFn
+  field_name: _0
+  fn_map: Some(Fn(&bool, &u16) -> Option<Vec<u8>>)
+  marker: null
+"#,
+    )?;
+
+    assert!(!params_spec.is_usable());
     Ok(())
 }

--- a/workspace_tests/src/params/params_spec_fieldless.rs
+++ b/workspace_tests/src/params/params_spec_fieldless.rs
@@ -1,4 +1,4 @@
-use peace::params::{ParamsFieldless, ParamsSpecFieldless};
+use peace::params::{ParamsFieldless, ParamsSpecFieldless, ValueSpecRt};
 
 #[test]
 fn serialize_stored() -> Result<(), serde_yaml::Error> {
@@ -115,5 +115,31 @@ marker: null
         "was {deserialized:?}"
     );
 
+    Ok(())
+}
+
+#[test]
+fn is_usable_returns_true_for_stored_value_in_memory() {
+    assert!(ParamsSpecFieldless::<u8>::Stored.is_usable());
+    assert!(ParamsSpecFieldless::<u8>::Value { value: 1u8 }.is_usable());
+    assert!(ParamsSpecFieldless::<u8>::InMemory.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_when_mapping_fn_is_some() {
+    assert!(ParamsSpecFieldless::<u8>::from_map(None, |_: &u8| None).is_usable());
+}
+
+#[test]
+fn is_usable_returns_false_when_mapping_fn_is_none() -> Result<(), serde_yaml::Error> {
+    let params_spec: ParamsSpecFieldless<u8> = serde_yaml::from_str(
+        r#"!MappingFn
+field_name: null
+fn_map: Some(Fn(&bool, &u16) -> Option<u8>)
+marker: null
+"#,
+    )?;
+
+    assert!(!params_spec.is_usable());
     Ok(())
 }

--- a/workspace_tests/src/params/params_spec_fieldless.rs
+++ b/workspace_tests/src/params/params_spec_fieldless.rs
@@ -1,4 +1,4 @@
-use peace::params::{ParamsFieldless, ParamsSpecFieldless, ValueSpecRt};
+use peace::params::{AnySpecRt, ParamsFieldless, ParamsSpecFieldless};
 
 #[test]
 fn serialize_stored() -> Result<(), serde_yaml::Error> {

--- a/workspace_tests/src/params/params_spec_fieldless.rs
+++ b/workspace_tests/src/params/params_spec_fieldless.rs
@@ -119,8 +119,12 @@ marker: null
 }
 
 #[test]
-fn is_usable_returns_true_for_stored_value_in_memory() {
-    assert!(ParamsSpecFieldless::<u8>::Stored.is_usable());
+fn is_usable_returns_false_for_stored() {
+    assert!(!ParamsSpecFieldless::<u8>::Stored.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_for_value_and_in_memory() {
     assert!(ParamsSpecFieldless::<u8>::Value { value: 1u8 }.is_usable());
     assert!(ParamsSpecFieldless::<u8>::InMemory.is_usable());
 }

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -118,8 +118,12 @@ marker: null
 }
 
 #[test]
-fn is_usable_returns_true_for_stored_value_in_memory() {
-    assert!(ValueSpec::<u8>::Stored.is_usable());
+fn is_usable_returns_false_for_stored() {
+    assert!(!ValueSpec::<u8>::Stored.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_for_value_and_in_memory() {
     assert!(ValueSpec::<u8>::Value { value: 1u8 }.is_usable());
     assert!(ValueSpec::<u8>::InMemory.is_usable());
 }

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -1,4 +1,4 @@
-use peace::params::{ValueSpec, ValueSpecRt};
+use peace::params::{AnySpecRt, ValueSpec};
 
 #[test]
 fn serialize_stored() -> Result<(), serde_yaml::Error> {

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -1,0 +1,118 @@
+use peace::params::ValueSpec;
+
+#[test]
+fn serialize_stored() -> Result<(), serde_yaml::Error> {
+    let u8_spec = ValueSpec::<u8>::Stored;
+    assert_eq!(
+        r#"Stored
+"#,
+        serde_yaml::to_string(&u8_spec)?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn serialize_value() -> Result<(), serde_yaml::Error> {
+    let u8_spec: ValueSpec<u8> = 1u8.into();
+    assert_eq!(
+        r#"!Value
+value: 1
+"#,
+        serde_yaml::to_string(&u8_spec)?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn serialize_in_memory() -> Result<(), serde_yaml::Error> {
+    let u8_spec = ValueSpec::<u8>::InMemory;
+    assert_eq!(
+        r#"InMemory
+"#,
+        serde_yaml::to_string(&u8_spec)?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn serialize_from_map() -> Result<(), serde_yaml::Error> {
+    let u8_spec: ValueSpec<u8> = ValueSpec::<u8>::from_map(None, |_: &bool, _: &u16| Some(1u8));
+    assert_eq!(
+        r#"!MappingFn
+field_name: null
+fn_map: Some(Fn(&bool, &u16) -> Option<u8>)
+marker: null
+"#,
+        serde_yaml::to_string(&u8_spec)?,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_stored() -> Result<(), serde_yaml::Error> {
+    assert!(matches!(
+        serde_yaml::from_str(
+            r#"Stored
+        "#
+        )?,
+        ValueSpec::<u8>::Stored
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_value() -> Result<(), serde_yaml::Error> {
+    assert!(matches!(
+        serde_yaml::from_str(
+            r#"!Value
+value: 1
+"#
+        )?,
+        ValueSpec::<u8>::Value { value }
+        if value == 1u8
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_in_memory() -> Result<(), serde_yaml::Error> {
+    let deserialized = serde_yaml::from_str(
+        r#"InMemory
+"#,
+    )?;
+
+    assert!(
+        matches!(&deserialized, ValueSpec::<u8>::InMemory),
+        "was {deserialized:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_from_map() -> Result<(), serde_yaml::Error> {
+    let deserialized = serde_yaml::from_str(
+        r#"!MappingFn
+field_name: null
+fn_map: Some(Fn(&bool, &u16) -> Option<Vec<u8>>)
+marker: null
+"#,
+    )?;
+
+    assert!(
+        matches!(
+            &deserialized,
+            ValueSpec::<u8>::MappingFn(mapping_fn)
+            if !mapping_fn.is_valued()
+        ),
+        "was {deserialized:?}"
+    );
+
+    Ok(())
+}

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -1,4 +1,4 @@
-use peace::params::ValueSpec;
+use peace::params::{ValueSpec, ValueSpecRt};
 
 #[test]
 fn serialize_stored() -> Result<(), serde_yaml::Error> {
@@ -100,7 +100,7 @@ fn deserialize_from_map() -> Result<(), serde_yaml::Error> {
     let deserialized = serde_yaml::from_str(
         r#"!MappingFn
 field_name: null
-fn_map: Some(Fn(&bool, &u16) -> Option<Vec<u8>>)
+fn_map: Some(Fn(&bool, &u16) -> Option<u8>)
 marker: null
 "#,
     )?;
@@ -114,5 +114,31 @@ marker: null
         "was {deserialized:?}"
     );
 
+    Ok(())
+}
+
+#[test]
+fn is_usable_returns_true_for_stored_value_in_memory() {
+    assert!(ValueSpec::<u8>::Stored.is_usable());
+    assert!(ValueSpec::<u8>::Value { value: 1u8 }.is_usable());
+    assert!(ValueSpec::<u8>::InMemory.is_usable());
+}
+
+#[test]
+fn is_usable_returns_true_when_mapping_fn_is_some() {
+    assert!(ValueSpec::<u8>::from_map(None, |_: &u8| None).is_usable());
+}
+
+#[test]
+fn is_usable_returns_false_when_mapping_fn_is_none() -> Result<(), serde_yaml::Error> {
+    let params_spec: ValueSpec<u8> = serde_yaml::from_str(
+        r#"!MappingFn
+field_name: null
+fn_map: Some(Fn(&bool, &u16) -> Option<u8>)
+marker: null
+"#,
+    )?;
+
+    assert!(!params_spec.is_usable());
     Ok(())
 }


### PR DESCRIPTION
Closes #122.