### PR TITLE
Web interface experiment.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -45,7 +45,7 @@ jobs:
           args: mdbook-graphviz --version 0.1.4
 
       # When updating this, also update ci.yml
-      - name: 'Build examples'
+      - name: 'Example: download (WASM)'
         # The following no longer works, because the AWS SDK uses tokio with UDP features enabled:
         # for example in $(ls examples)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,11 @@ jobs:
           components: clippy
 
       - name: 'Run clippy'
+        # we cannot use `--all-features` because `envman` has features that are mutually exclusive.
         run: |
           cargo clippy \
             --workspace \
-            --all-features \
+            --features "cli error_reporting output_colorized output_json output_progress" \
             --fix \
             --exclude peace_rt_model_web \
             -- -D warnings
@@ -161,7 +162,7 @@ jobs:
   build_and_test_linux:
     name: Build and Test (Linux)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - # FIXME: Switch back when actions-rs/toolchain#{209,220,222} is merged
@@ -173,7 +174,8 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
       - name: 'Build and test'
-        run: cargo nextest run --workspace --all-features
+        run: |
+          for j in {0..4}; do cargo test_$j || break; done
 
   build_and_test_windows:
     name: Build and Test (Windows)
@@ -195,8 +197,8 @@ jobs:
       - name: 'Build and test'
         run: cargo nextest run --workspace --all-features
 
-  build_examples_wasm:
-    name: Build examples (WASM)
+  build_examples:
+    name: Build examples -- Native, WASM, leptos
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -211,10 +213,30 @@ jobs:
       - name: 'Install `wasm-pack`'
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'v0.11.1'
+          version: 'latest'
+
+      - name: cargo-leptos cache
+        id: cargo-leptos-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-leptos
+          key: cargo-leptos-${{ runner.os }}
+
+      - name: cargo-leptos install
+        if: steps.cargo-leptos-cache.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/leptos-rs/cargo-leptos.git --locked cargo-leptos
+
+      - name: 'Example: download (native)'
+        run: cargo build --package download --all-features
+
+      - name: 'Example: envman (native)'
+        run: cargo build --package envman --features cli
+
+      - name: 'Example: envman (leptos)'
+        run: cargo leptos build --project "envman" -v
 
       # When updating this, also update book.yml
-      - name: 'Build examples'
+      - name: 'Example: download (WASM)'
         # The following no longer works, because the AWS SDK uses tokio with UDP features enabled:
         # for example in $(ls examples)
         run: |
@@ -226,3 +248,4 @@ jobs:
             "examples/${example}" \
             --features 'error_reporting output_colorized output_json'
           done
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
   build_examples:
     name: Build examples -- Native, WASM, leptos
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - # FIXME: Switch back when actions-rs/toolchain#{209,220,222} is merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Implement one level recursion referential item params. ([#119], [#121])
 * Implement deep merging of params specs. ([#122], [#123])
 * Calculate padding for progress bar item IDs. ([#46], [#124])
+* Implement `Clone`, `PartialEq` for `Flow`. ([#125], [#126])
 
 [#116]: https://github.com/azriel91/peace/issues/116
 [#117]: https://github.com/azriel91/peace/pull/117
@@ -24,6 +25,8 @@
 [#123]: https://github.com/azriel91/peace/pull/123
 [#46]: https://github.com/azriel91/peace/issues/46
 [#124]: https://github.com/azriel91/peace/pull/124
+[#125]: https://github.com/azriel91/peace/issues/125
+[#126]: https://github.com/azriel91/peace/pull/126
 
 
 ## 0.0.9 (2023-04-13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 cfg-if = "1.0.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"] }
 derivative = "2.2.0"
-fn_graph = { version = "0.8.2", features = ["resman"] }
+fn_graph = { version = "0.8.3", features = ["resman"] }
 indexmap = "1.9.3"
 indicatif = { version = "0.17.3" }
 miette = { version = "5.7.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
 cfg-if = "1.0.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"] }
 derivative = "2.2.0"
+fn_graph = { version = "0.8.2", features = ["resman"] }
 indexmap = "1.9.3"
 indicatif = { version = "0.17.3" }
 miette = { version = "5.7.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ chrono = { version = "0.4.24", default-features = false, features = ["clock", "s
 derivative = "2.2.0"
 fn_graph = { version = "0.8.3", features = ["resman"] }
 indexmap = "1.9.3"
-indicatif = { version = "0.17.3" }
+indicatif = { version = "0.17.4" }
 miette = { version = "5.7.0" }
 tar = "0.4.38"
 tokio = "1.27.0"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # Development
 
-## Dependencies
+## Rust Development
+
+### Dependencies
 
 ```bash
 rustup component add llvm-tools-preview
@@ -9,7 +11,7 @@ cargo install cargo-nextest
 ```
 
 
-## Running Tests
+### Running Tests
 
 ```bash
 cargo nextest run --workspace --all-features
@@ -19,7 +21,7 @@ for i in {0..3}; do cargo test_$i || break; done
 ```
 
 
-## Coverage
+### Coverage
 
 Collect coverage and output as `lcov`.
 
@@ -34,7 +36,7 @@ Collect coverage and open `html` report.
 ```
 
 
-## Releasing
+### Releasing
 
 1. Update crate versions.
 
@@ -58,3 +60,90 @@ Collect coverage and open `html` report.
 
 [`publish`]: https://github.com/azriel91/peace/actions/workflows/publish.yml
 [`crates.io`]:https://crates.io/
+
+
+## Web Development
+
+### Set Up
+
+These instructions are for Linux. They may work on OS X, but for Windows, please visit each linked site for specific instructions.
+
+1. Install [`nvm`]:
+
+    ```bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+    ```
+
+2. Install node and set the default version:
+
+    ```bash
+    nvm install 20
+    nvm alias default 20
+    ```
+
+3. Install and set up `pnpm`:
+
+    ```bash
+    npm install -g pnpm
+    pnpm setup
+    ```
+
+4. Install [tailwindcss]:
+
+    ```bash
+    pnpm install --global tailwindcss
+    ```
+
+5. Install [`cargo-watch`]
+
+    ```bash
+    cargo install cargo-watch
+    ```
+
+
+**Notes:**
+
+* `pnpm` is used because it downloads each version of each library once, whereas `npm` downloads all dependencies recursively, even if the same dependency is already existent in the dependency tree.
+* This is installed as a global binary instead of as a dev dependency within the repository. This is more aligned with Rust's single-binary installation model.
+
+
+[`cargo-watch`]: https://github.com/watchexec/cargo-watch
+[`nvm`]: https://github.com/nvm-sh/nvm
+[tailwindcss]: https://tailwindcss.com/
+
+
+### Development
+
+> ℹ️ These commands assume you are running them from the repository root directory.
+
+Run the `tailwindcss` command to generate the example's CSS:
+
+```bash
+tailwindcss \
+  -i examples/envman/src/web/tailwind.css \
+  -o target/web/envman/public/css/tailwind.css \
+  --watch
+```
+
+Build and serve the example:
+
+```bash
+# For watching and auto reloading
+cargo watch \
+  -x 'build --package envman --all-features' \
+  -s "bash -c '(cd target/web/envman && ../../debug/envman web)'"
+
+# For a single execution
+cargo build --package envman --all-features &&
+  (cd target/web/envman && ../../debug/envman web)
+```
+
+### Uninstallation
+
+To uninstall web tooling:
+
+```bash
+pnpm uninstall --global tailwindcss
+nvm uninstall $version
+rm -rf ~/.nvm
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,10 +94,10 @@ These instructions are for Linux. They may work on OS X, but for Windows, please
     pnpm install --global tailwindcss
     ```
 
-5. Install [`cargo-watch`]
+5. Install [`cargo-leptos`]:
 
     ```bash
-    cargo install cargo-watch
+    cargo install --git https://github.com/leptos-rs/cargo-leptos.git --locked cargo-leptos
     ```
 
 
@@ -107,7 +107,7 @@ These instructions are for Linux. They may work on OS X, but for Windows, please
 * This is installed as a global binary instead of as a dev dependency within the repository. This is more aligned with Rust's single-binary installation model.
 
 
-[`cargo-watch`]: https://github.com/watchexec/cargo-watch
+[`cargo-leptos`]: https://github.com/leptos-rs/cargo-leptos
 [`nvm`]: https://github.com/nvm-sh/nvm
 [tailwindcss]: https://tailwindcss.com/
 
@@ -116,26 +116,10 @@ These instructions are for Linux. They may work on OS X, but for Windows, please
 
 > ℹ️ These commands assume you are running them from the repository root directory.
 
-Run the `tailwindcss` command to generate the example's CSS:
+Build and serve the `envman` example:
 
 ```bash
-tailwindcss \
-  -i examples/envman/src/web/tailwind.css \
-  -o target/web/envman/public/css/tailwind.css \
-  --watch
-```
-
-Build and serve the example:
-
-```bash
-# For watching and auto reloading
-cargo watch \
-  -x 'build --package envman --all-features' \
-  -s "bash -c '(cd target/web/envman && ../../debug/envman web)'"
-
-# For a single execution
-cargo build --package envman --all-features &&
-  (cd target/web/envman && ../../debug/envman web)
+cargo leptos serve --project "envman" -v
 ```
 
 ### Uninstallation

--- a/about.toml
+++ b/about.toml
@@ -1,9 +1,12 @@
 accepted = [
     "Apache-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
     "NOASSERTION",
     "OpenSSL",
+    "Zlib",
 ]

--- a/crate/cmd/src/ctx/cmd_ctx_builder.rs
+++ b/crate/cmd/src/ctx/cmd_ctx_builder.rs
@@ -242,7 +242,10 @@ pub(crate) async fn profiles_from_peace_app_dir(
 /// deserialization.
 fn params_and_states_type_reg<E>(
     item_graph: &ItemGraph<E>,
-) -> (ItemParamsTypeReg, ParamsSpecsTypeReg, StatesTypeReg) {
+) -> (ItemParamsTypeReg, ParamsSpecsTypeReg, StatesTypeReg)
+where
+    E: 'static,
+{
     item_graph.iter().fold(
         (
             ItemParamsTypeReg::new(),
@@ -272,7 +275,7 @@ fn params_specs_merge<E>(
     params_specs_stored: Option<ParamsSpecs>,
 ) -> Result<ParamsSpecs, Error>
 where
-    E: From<Error>,
+    E: From<Error> + 'static,
 {
     // Combine provided and stored params specs. Provided params specs take
     // precedence.
@@ -378,7 +381,7 @@ async fn item_graph_setup<E>(
     resources: Resources<Empty>,
 ) -> Result<Resources<SetUp>, E>
 where
-    E: std::error::Error,
+    E: std::error::Error + 'static,
 {
     let resources = item_graph
         .stream()

--- a/crate/cmd/src/scopes/single_profile_single_flow.rs
+++ b/crate/cmd/src/scopes/single_profile_single_flow.rs
@@ -51,6 +51,7 @@ use serde::{de::DeserializeOwned, Serialize};
 #[derive(Debug)]
 pub struct SingleProfileSingleFlow<'ctx, E, O, PKeys, TS>
 where
+    E: 'static,
     PKeys: ParamsKeys + 'static,
 {
     /// Output endpoint to return values / errors, and write progress
@@ -151,6 +152,7 @@ where
 #[derive(Debug)]
 pub struct SingleProfileSingleFlowView<'view, E, O, PKeys, TS>
 where
+    E: 'static,
     PKeys: ParamsKeys + 'static,
 {
     /// Output endpoint to return values / errors, and write progress

--- a/crate/code_gen/Cargo.toml
+++ b/crate/code_gen/Cargo.toml
@@ -17,6 +17,6 @@ doctest = true
 test = false
 
 [dependencies]
-syn = { version = "2.0.13", features = ["full"] }
+syn = { version = "2.0.18", features = ["full"] }
 quote = "1.0.26"
 proc-macro2 = "1.0.56"

--- a/crate/code_gen/src/cmd/impl_build.rs
+++ b/crate/code_gen/src/cmd/impl_build.rs
@@ -205,7 +205,7 @@ fn impl_build_for(
                 >,
             >
         where
-            E: std::error::Error + From<peace_rt_model::Error>,
+            E: std::error::Error + From<peace_rt_model::Error> + 'static,
             PKeys: #params_module::ParamsKeys + 'static,
         {
             /// Builds the command context.

--- a/crate/code_gen/src/cmd/impl_common_fns.rs
+++ b/crate/code_gen/src/cmd/impl_common_fns.rs
@@ -31,7 +31,7 @@ pub fn impl_common_fns(scope_struct: &ScopeStruct) -> proc_macro2::TokenStream {
             ) -> Self
             where
                 IS: peace_cfg::Item,
-                E: From<IS::Error> + 'static,
+                E: From<IS::Error>,
             {
                 self.scope_builder.params_specs_provided.insert(item_id, params_spec);
                 self

--- a/crate/code_gen/src/cmd/impl_common_fns.rs
+++ b/crate/code_gen/src/cmd/impl_common_fns.rs
@@ -31,7 +31,7 @@ pub fn impl_common_fns(scope_struct: &ScopeStruct) -> proc_macro2::TokenStream {
             ) -> Self
             where
                 IS: peace_cfg::Item,
-                E: From<IS::Error>
+                E: From<IS::Error> + 'static,
             {
                 self.scope_builder.params_specs_provided.insert(item_id, params_spec);
                 self
@@ -67,7 +67,7 @@ pub fn impl_common_fns(scope_struct: &ScopeStruct) -> proc_macro2::TokenStream {
                 >,
             >
         where
-            E: std::error::Error + From<peace_rt_model::Error>,
+            E: std::error::Error + From<peace_rt_model::Error> + 'static,
             PKeys: #params_module::ParamsKeys + 'static,
         {
             #common_fns

--- a/crate/data/Cargo.toml
+++ b/crate/data/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 test = false
 
 [dependencies]
-fn_graph = { version = "0.8.2", features = ["resman"] }
+fn_graph = { workspace = true }
 peace_core = { path = "../core", version = "0.0.9" }
 peace_data_derive = { path = "../data_derive", version = "0.0.9" }
 serde = { version = "1.0.159", features = ["derive"] }

--- a/crate/data_derive/Cargo.toml
+++ b/crate/data_derive/Cargo.toml
@@ -17,6 +17,6 @@ doctest = false
 test = false
 
 [dependencies]
-syn = "2.0.13"
+syn = "2.0.18"
 quote = "1.0.26"
 proc-macro2 = "1.0.56"

--- a/crate/params/src/func.rs
+++ b/crate/params/src/func.rs
@@ -1,0 +1,70 @@
+/// Provides a simpler constraint for the compiler to report to the developer.
+///
+/// Implemented for up to five arguments.
+///
+/// Instead of the detailed error message from the `From` trait:
+///
+/// ```md
+/// the trait `From<(
+///     std::option::Option<std::string::String>,
+///     [closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73],
+/// )>`
+/// is not implemented for
+/// `MappingFnImpl<
+///     std::string::String,
+///     [closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73],
+///     _,
+/// >`
+/// ```
+///
+/// we get the much clearer:
+///
+/// ```md
+/// the trait `Func<std::option::Option<std::string::String>, _>`
+/// is not implemented for closure `[closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73]`
+/// ```
+pub trait Func<ReturnType, Args> {}
+
+macro_rules! impl_func_for_f {
+    ($($Arg:ident),+) => {
+        impl<T, F, $($Arg,)+> Func<T, ($($Arg,)+)> for F
+        where F: Fn($(&$Arg,)+) -> T {}
+    };
+}
+
+impl_func_for_f!(A0);
+impl_func_for_f!(A0, A1);
+impl_func_for_f!(A0, A1, A2);
+impl_func_for_f!(A0, A1, A2, A3);
+impl_func_for_f!(A0, A1, A2, A3, A4);
+
+/// Provides a simpler constraint for the compiler to report to the developer.
+///
+/// Instead of the detailed error message from the `From` trait:
+///
+/// ```md
+/// the trait `From<(
+///     std::option::Option<std::string::String>,
+///     [closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73],
+/// )>`
+/// is not implemented for
+/// `MappingFnImpl<
+///     std::string::String,
+///     [closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73],
+///     _,
+/// >`
+/// ```
+///
+/// we get:
+///
+/// ```md
+/// the trait `FromFunc<[closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73]>`
+/// is not implemented for `MappingFnImpl<
+///     std::string::String,
+///     [closure@examples/envman/src/flows/app_upload_flow.rs:101:40: 101:73],
+///     _,
+/// >`
+/// ```
+pub trait FromFunc<F> {
+    fn from_func(field_name: Option<String>, f: F) -> Self;
+}

--- a/crate/params/src/lib.rs
+++ b/crate/params/src/lib.rs
@@ -64,14 +64,26 @@ pub use peace_params_derive::{value_impl, Params, ParamsFieldless};
 pub use tynm;
 
 pub use crate::{
-    any_spec_data_type::AnySpecDataType, any_spec_rt::AnySpecRt, any_spec_rt_boxed::AnySpecRtBoxed,
-    field_name_and_type::FieldNameAndType, field_wise_spec_rt::FieldWiseSpecRt,
-    mapping_fn::MappingFn, mapping_fn_impl::MappingFnImpl, params::Params,
-    params_fieldless::ParamsFieldless, params_resolve_error::ParamsResolveError,
-    params_spec::ParamsSpec, params_spec_de::ParamsSpecDe,
-    params_spec_fieldless::ParamsSpecFieldless, params_spec_fieldless_de::ParamsSpecFieldlessDe,
-    params_specs::ParamsSpecs, value_resolution_ctx::ValueResolutionCtx,
-    value_resolution_mode::ValueResolutionMode, value_spec::ValueSpec, value_spec_de::ValueSpecDe,
+    any_spec_data_type::AnySpecDataType,
+    any_spec_rt::AnySpecRt,
+    any_spec_rt_boxed::AnySpecRtBoxed,
+    field_name_and_type::FieldNameAndType,
+    field_wise_spec_rt::FieldWiseSpecRt,
+    func::{FromFunc, Func},
+    mapping_fn::MappingFn,
+    mapping_fn_impl::MappingFnImpl,
+    params::Params,
+    params_fieldless::ParamsFieldless,
+    params_resolve_error::ParamsResolveError,
+    params_spec::ParamsSpec,
+    params_spec_de::ParamsSpecDe,
+    params_spec_fieldless::ParamsSpecFieldless,
+    params_spec_fieldless_de::ParamsSpecFieldlessDe,
+    params_specs::ParamsSpecs,
+    value_resolution_ctx::ValueResolutionCtx,
+    value_resolution_mode::ValueResolutionMode,
+    value_spec::ValueSpec,
+    value_spec_de::ValueSpecDe,
     value_spec_rt::ValueSpecRt,
 };
 
@@ -80,6 +92,7 @@ mod any_spec_rt;
 mod any_spec_rt_boxed;
 mod field_name_and_type;
 mod field_wise_spec_rt;
+mod func;
 mod mapping_fn;
 mod mapping_fn_impl;
 mod params;

--- a/crate/params_derive/Cargo.toml
+++ b/crate/params_derive/Cargo.toml
@@ -20,4 +20,4 @@ test = false
 heck = "0.4.1"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
-syn = { version = "2.0.13", features = ["extra-traits"] }
+syn = { version = "2.0.18", features = ["extra-traits"] }

--- a/crate/params_derive/src/impl_field_wise_builder.rs
+++ b/crate/params_derive/src/impl_field_wise_builder.rs
@@ -420,14 +420,25 @@ fn builder_field_methods(
 
                 pub fn #with_field_name_from_map<F, Args>(mut self, f: F) -> Self
                 where
+                    F: #peace_params_path::Func<
+                        Option<#field_ty>,
+                        Args,
+                    >,
                     #peace_params_path::MappingFnImpl<#field_ty, F, Args>:
-                        From<(Option<String>, F)>
+                        #peace_params_path::FromFunc<F>
                         + #peace_params_path::MappingFn<Output = #field_ty>
                 {
-                    self #proxy_call.#self_field_name = Some(#field_spec_ty_path::from_map(
-                        Some(String::from(stringify!(#field_name))),
-                        f,
-                    ));
+                    let spec = {
+                        let mapping_fn = <
+                                #peace_params_path::MappingFnImpl<#field_ty, F, Args>
+                                as #peace_params_path::FromFunc<F>
+                            >::from_func(
+                            Some(String::from(stringify!(#field_name))),
+                            f,
+                        );
+                        #field_spec_ty_path::MappingFn(Box::new(mapping_fn))
+                    };
+                    self #proxy_call.#self_field_name = Some(spec);
                     self
                 }
             }

--- a/crate/rt_model/Cargo.toml
+++ b/crate/rt_model/Cargo.toml
@@ -19,7 +19,6 @@ test = false
 cfg-if = { workspace = true }
 dyn-clone = "1.0.11"
 erased-serde = "0.3.25"
-fn_graph = { version = "0.8.2", features = ["resman"] }
 futures = "0.3.28"
 indicatif = { workspace = true, features = ["tokio"] }
 miette = { workspace = true, optional = true }

--- a/crate/rt_model/src/flow.rs
+++ b/crate/rt_model/src/flow.rs
@@ -8,8 +8,11 @@ use crate::ItemGraph;
 /// contains the definitions to read and write the items' [`State`]s.
 ///
 /// [`State`]: peace_cfg::Item::State
-#[derive(Debug)]
-pub struct Flow<E> {
+#[derive(Debug, PartialEq, Eq)]
+pub struct Flow<E>
+where
+    E: 'static,
+{
     /// ID of this flow.
     flow_id: FlowId,
     /// Graph of [`Item`]s in this flow.

--- a/crate/rt_model/src/flow.rs
+++ b/crate/rt_model/src/flow.rs
@@ -27,6 +27,15 @@ where
     }
 }
 
+impl<E> Clone for Flow<E> {
+    fn clone(&self) -> Self {
+        Self {
+            flow_id: self.flow_id.clone(),
+            graph: self.graph.clone(),
+        }
+    }
+}
+
 impl<E> Eq for Flow<E> where E: 'static {}
 
 impl<E> Flow<E> {

--- a/crate/rt_model/src/flow.rs
+++ b/crate/rt_model/src/flow.rs
@@ -8,11 +8,8 @@ use crate::ItemGraph;
 /// contains the definitions to read and write the items' [`State`]s.
 ///
 /// [`State`]: peace_cfg::Item::State
-#[derive(Debug, PartialEq, Eq)]
-pub struct Flow<E>
-where
-    E: 'static,
-{
+#[derive(Debug)]
+pub struct Flow<E> {
     /// ID of this flow.
     flow_id: FlowId,
     /// Graph of [`Item`]s in this flow.
@@ -20,6 +17,17 @@ where
     /// [`Item`]: peace_cfg::Item
     graph: ItemGraph<E>,
 }
+
+impl<E> PartialEq for Flow<E>
+where
+    E: 'static,
+{
+    fn eq(&self, other: &Flow<E>) -> bool {
+        self.flow_id == other.flow_id && self.graph == other.graph
+    }
+}
+
+impl<E> Eq for Flow<E> where E: 'static {}
 
 impl<E> Flow<E> {
     /// Returns a new `Flow`.

--- a/crate/rt_model/src/item_boxed.rs
+++ b/crate/rt_model/src/item_boxed.rs
@@ -15,8 +15,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use fn_graph::{DataAccessDyn, TypeIds};
 use peace_cfg::Item;
+use peace_data::fn_graph::{DataAccessDyn, TypeIds};
 use peace_params::Params;
 
 use crate::{ItemRt, ItemWrapper};

--- a/crate/rt_model/src/item_boxed.rs
+++ b/crate/rt_model/src/item_boxed.rs
@@ -53,6 +53,17 @@ impl<E> DerefMut for ItemBoxed<E> {
     }
 }
 
+impl<E> PartialEq for ItemBoxed<E>
+where
+    E: 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&*other.0)
+    }
+}
+
+impl<E> Eq for ItemBoxed<E> where E: 'static {}
+
 impl<I, E> From<I> for ItemBoxed<E>
 where
     I: Clone + Debug + Item + Send + Sync + 'static,

--- a/crate/rt_model/src/item_graph.rs
+++ b/crate/rt_model/src/item_graph.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use fn_graph::FnGraph;
+use peace_data::fn_graph::FnGraph;
 
 use crate::ItemBoxed;
 

--- a/crate/rt_model/src/item_graph.rs
+++ b/crate/rt_model/src/item_graph.rs
@@ -18,6 +18,17 @@ impl<E> Clone for ItemGraph<E> {
     }
 }
 
+impl<E> PartialEq for ItemGraph<E>
+where
+    E: 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<E> Eq for ItemGraph<E> where E: 'static {}
+
 impl<E> ItemGraph<E> {
     /// Returns the inner [`FnGraph`].
     pub fn into_inner(self) -> FnGraph<ItemBoxed<E>> {

--- a/crate/rt_model/src/item_graph_builder.rs
+++ b/crate/rt_model/src/item_graph_builder.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use fn_graph::FnGraphBuilder;
+use peace_data::fn_graph::FnGraphBuilder;
 
 use crate::{ItemBoxed, ItemGraph};
 

--- a/crate/rt_model/src/item_rt.rs
+++ b/crate/rt_model/src/item_rt.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use dyn_clone::DynClone;
-use fn_graph::{DataAccess, DataAccessDyn};
 use peace_cfg::{async_trait, FnCtx, ItemId};
+use peace_data::fn_graph::{DataAccess, DataAccessDyn};
 use peace_params::ParamsSpecs;
 use peace_resources::{
     resources::ts::{Empty, SetUp},

--- a/crate/rt_model/src/item_wrapper.rs
+++ b/crate/rt_model/src/item_wrapper.rs
@@ -4,9 +4,9 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use fn_graph::{DataAccess, DataAccessDyn, TypeIds};
 use peace_cfg::{async_trait, ApplyCheck, FnCtx, Item, ItemId};
 use peace_data::{
+    fn_graph::{DataAccess, DataAccessDyn, TypeIds},
     marker::{ApplyDry, Clean, Current, Desired},
     Data,
 };

--- a/crate/rt_model/src/lib.rs
+++ b/crate/rt_model/src/lib.rs
@@ -4,7 +4,7 @@
 //! `peace_rt_model_web` depending on the compilation target architecture.
 
 // Re-exports
-pub use fn_graph::{self, FnRef};
+pub use peace_data::fn_graph::{self, FnRef};
 pub use peace_rt_model_core::*;
 
 pub mod output {

--- a/crate/static_check_macros/Cargo.toml
+++ b/crate/static_check_macros/Cargo.toml
@@ -17,6 +17,6 @@ doctest = true
 test = false
 
 [dependencies]
-syn = "2.0.13"
+syn = "2.0.18"
 quote = "1.0.26"
 proc-macro2 = "1.0.56"

--- a/deny.toml
+++ b/deny.toml
@@ -75,11 +75,6 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
     #"RUSTSEC-0000-0000",
-
-    # atty has a soundness issue, depended on by miette
-    # https://github.com/softprops/atty/issues/50
-    # https://github.com/zkat/miette/issues/228
-    "RUSTSEC-2021-0145",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -110,12 +105,15 @@ unlicensed = "deny"
 # Keep in sync with about.toml
 allow = [
     "Apache-2.0",
-    # "BSD-3-Clause", # wasm
+    "BSD-2-Clause",
+    "BSD-3-Clause", # wasm
+    "BSL-1.0",
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
     "NOASSERTION",
     "OpenSSL",
+    "Zlib",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -246,11 +244,6 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
-
-    # miette -> atty -> hermit-abi
-    # Would be resolved by:
-    # # https://github.com/zkat/miette/issues/228
-    { name = "hermit-abi", version = "=0.1.19" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/doc/src/ideas.md
+++ b/doc/src/ideas.md
@@ -222,6 +222,15 @@ Or, all dest parameters should be in `Item::State`, because that's what's needed
 </div>
 </details>
 
+<details>
+<summary>15. Use <a href="https://openlayers.org/">openlayers</a> for tiling level of detail</summary>
+<div>
+
+Generate dot diagram using graphviz with full resolution, and then convert to tiles, then display different styling depending on the state of each item.
+
+</div>
+</details>
+
 
 ## Notes
 

--- a/doc/src/learning_material/empathetic_code_design/profiles.md
+++ b/doc/src/learning_material/empathetic_code_design/profiles.md
@@ -7,6 +7,9 @@ First execution / init:
 ```rust ,ignore
 let cmd_ctx_builder = CmdCtx::builder_single_profile_no_flow
     ::<EnvManError, _>(output, &workspace)
+    .with_profile(profile!("demo"))
+
+    // for recall
     .with_workspace_param_value(
         WorkspaceParamsKey::Profile,
         Some(profile!("demo")),

--- a/doc/src/learning_material/empathetic_code_design/summary.md
+++ b/doc/src/learning_material/empathetic_code_design/summary.md
@@ -5,5 +5,5 @@ How do we communicate clearly in code?
 * Consistency between the conceptual model and the written code.
 * Make use of type safety with strong types.
 * When we require something of the developer, make it easy to be provided.
-* Error messages at compile time should be clear.
-* Error messages at runtime should be clear.
+* Prefer errors at compile time than runtime.
+* Error messages should show what is wrong and how to fix it.

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -65,7 +65,7 @@ js-sys = "0.3.61"
 web-sys = "0.3.61"
 
 [features]
-default = ["cli"]
+default = []
 
 # === envman modes === #
 cli = [

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -43,8 +43,8 @@ axum = { version = "0.6.18", optional = true }
 hyper = { version = "0.14.26", optional = true }
 leptos = { version = "0.3.0", default-features = false, features = ["serde", "stable"] }
 leptos_axum = { version = "0.3.0", optional = true }
-leptos_meta = { version = "0.3.0", default-features = false }
-leptos_router = { version = "0.3.0", default-features = false }
+leptos_meta = { version = "0.3.0", default-features = false, features = ["stable"] }
+leptos_router = { version = "0.3.0", default-features = false, features = ["stable"] }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4.0", optional = true, features = ["fs"] }
 tracing = { version = "0.1.37", optional = true }

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -54,6 +54,9 @@ clap = { version = "4.2.1", features = ["derive"], optional = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = { version = "1.0.0", features = ["color"] }
+log = "0.4.18"
 serde-wasm-bindgen = "0.5.0"
 tokio = { workspace = true }
 wasm-bindgen = "0.2.84"
@@ -62,9 +65,46 @@ js-sys = "0.3.61"
 web-sys = "0.3.61"
 
 [features]
-default = ["flow_logic", "web_server"]
+default = ["cli"]
 
-# peace features
+# === envman modes === #
+cli = [
+    "error_reporting",
+    "output_colorized",
+    "output_json",
+    "output_progress",
+
+    "flow_logic",
+    "web_server",
+]
+# The `"ssr"` feature is used for two purposes:
+#
+# * To enable web server features.
+# * Without the `"cli"` feature enabled, that this is a plain web server binary.
+#
+# The reason we use "ssr" to enable web server features is because:
+#
+# * we need them enabled when the application is built as a CLI tool with web server capabilities.
+# * we need them enabled when the application is built as a plain web server.
+# * `cargo-leptos` enables the `"ssr"` feature.
+# * proc macros from `leptos` *probably* depend on `#[cfg(feature = "ssr")]`, which don't get
+#   enabled when we use `"web_server"` as the web server feature without enabling `"ssr"` as well.
+ssr = [
+    "flow_logic",
+    "web_components",
+    "dep:axum",
+    "dep:hyper",
+    "dep:leptos_axum",
+    "dep:tokio",
+    "dep:tower",
+    "dep:tower-http",
+    "leptos/ssr",
+    "leptos_meta/ssr",
+    "leptos_router/ssr",
+]
+csr = ["web_components"]
+
+# === peace passthrough features === #
 error_reporting = [
     "peace/error_reporting",
     "peace_items/error_reporting",
@@ -76,7 +116,7 @@ output_progress = [
     "peace_items/output_progress",
 ]
 
-# envman
+# === envman low level === #
 flow_logic = [
     "dep:aws-config",
     "dep:aws-sdk-iam",
@@ -96,28 +136,24 @@ flow_logic = [
 ]
 
 # web related
-web_server = [
-    "flow_logic",
-    "dep:axum",
-    "dep:hyper",
-    "dep:leptos_axum",
-    "dep:tokio",
-    "dep:tower",
-    "dep:tower-http",
+web_components = [
     "dep:tracing",
-    "leptos/ssr",
-    "leptos_meta/ssr",
-    "leptos_router/ssr",
+]
+web_server = [
+    "ssr", # leptos generates functions that depend on this feature in the application crate.
 ]
 
-# leptos
-# with ssr, the `main` function runs the server directly, without other CLI commands.
-ssr = ["web_server"]
+# leptos csr
 hydrate = [
+    "web_components",
     "leptos/hydrate",
     "leptos_meta/hydrate",
     "leptos_router/hydrate",
 ]
+
+[package.metadata.cargo-all-features]
+denylist = ["axum", "tower", "tower-http", "tokio", "leptos_axum"]
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # See <https://github.com/leptos-rs/cargo-leptos/blob/main/README.md>
@@ -162,7 +198,7 @@ env = "DEV"
 # Optional. Can be over-ridden with the command line parameter --bin-features
 bin-features = ["ssr"]
 
-# If the --no-default-features flag should be used when compiling the bin target
+# Whether default features should be enabled when compiling the bin target
 #
 # Optional. Defaults to false.
 bin-default-features = false
@@ -172,7 +208,7 @@ bin-default-features = false
 # Optional. Can be over-ridden with the command line parameter --lib-features
 lib-features = ["hydrate"]
 
-# If the --no-default-features flag should be used when compiling the lib target
+# Whether default features should be enabled when compiling the lib target
 #
 # Optional. Defaults to false.
 lib-default-features = false

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -40,6 +40,7 @@ whoami = "1.4.0"
 # web_server
 axum = { version = "0.6.18", optional = true }
 dioxus = { version = "0.3.2", optional = true }
+dioxus-liveview = { version = "0.3.0", optional = true, features = ["axum"] }
 dioxus-ssr = { version = "0.3.0", optional = true }
 hyper = { version = "0.14.26", optional = true }
 tower-http = { version = "0.4.0", optional = true, features = ["fs"] }
@@ -71,6 +72,7 @@ output_progress = [
 web_server = [
     "dep:axum",
     "dep:dioxus",
+    "dep:dioxus-liveview",
     "dep:dioxus-ssr",
     "dep:hyper",
     "dep:tower-http",

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -18,36 +18,40 @@ test = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aws-config = "0.55.0"
-aws-sdk-iam = "0.25.1"
-aws-sdk-s3 = "0.25.1"
-aws-smithy-http = "0.55.0" # used to reference error type, otherwise not recommended for direct usage
-base64 = "0.21.0"
+aws-config = { version = "0.55.0", optional = true }
+aws-sdk-iam = { version = "0.25.1", optional = true }
+aws-sdk-s3 = { version = "0.25.1", optional = true }
+aws-smithy-http = { version = "0.55.0", optional = true } # used to reference error type, otherwise not recommended for direct usage
+base64 = { version = "0.21.0", optional = true }
 cfg-if = { workspace = true }
-chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"] }
-derivative = { workspace = true }
-futures = "0.3.28"
-md5-rs = "0.1.5"  # WASM compatible, and reads bytes as stream
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "serde"], optional = true }
+derivative = { workspace = true, optional = true }
+futures = { version = "0.3.28", optional = true }
+md5-rs = { version = "0.1.5", optional = true }  # WASM compatible, and reads bytes as stream
 peace = { path = "../..", default-features = false }
 peace_items = { path = "../../items", features = ["file_download", "tar_x"] }
-semver = "1.0.17"
+semver = { version = "1.0.17", optional = true }
 serde = { version = "1.0.159", features = ["derive"] }
-thiserror = "1.0.40"
+thiserror = { version = "1.0.40", optional = true }
 url = { version = "2.3.1", features = ["serde"] }
-urlencoding = "2.1.2"
-whoami = "1.4.0"
+urlencoding = { version = "2.1.2", optional = true }
+whoami = { version = "1.4.0", optional = true }
 
 # web_server
+# ssr
 axum = { version = "0.6.18", optional = true }
-dioxus = { version = "0.3.2", optional = true }
-dioxus-liveview = { version = "0.3.0", optional = true, features = ["axum"] }
-dioxus-ssr = { version = "0.3.0", optional = true }
 hyper = { version = "0.14.26", optional = true }
+leptos = { version = "0.3.0", default-features = false, features = ["serde", "stable"] }
+leptos_axum = { version = "0.3.0", optional = true }
+leptos_meta = { version = "0.3.0", default-features = false }
+leptos_router = { version = "0.3.0", default-features = false }
+tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4.0", optional = true, features = ["fs"] }
+tracing = { version = "0.1.37", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-clap = { version = "4.2.1", features = ["derive"] }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+clap = { version = "4.2.1", features = ["derive"], optional = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 serde-wasm-bindgen = "0.5.0"
@@ -58,7 +62,9 @@ js-sys = "0.3.61"
 web-sys = "0.3.61"
 
 [features]
-default = ["web_server"]
+default = ["flow_logic", "web_server"]
+
+# peace features
 error_reporting = [
     "peace/error_reporting",
     "peace_items/error_reporting",
@@ -69,11 +75,104 @@ output_progress = [
     "peace/output_progress",
     "peace_items/output_progress",
 ]
-web_server = [
-    "dep:axum",
-    "dep:dioxus",
-    "dep:dioxus-liveview",
-    "dep:dioxus-ssr",
-    "dep:hyper",
-    "dep:tower-http",
+
+# envman
+flow_logic = [
+    "dep:aws-config",
+    "dep:aws-sdk-iam",
+    "dep:aws-sdk-s3",
+    "dep:aws-smithy-http",
+    "dep:base64",
+    "dep:chrono",
+    "dep:clap",
+    "dep:derivative",
+    "dep:futures",
+    "dep:md5-rs",
+    "dep:semver",
+    "dep:thiserror",
+    "dep:tokio",
+    "dep:urlencoding",
+    "dep:whoami",
 ]
+
+# web related
+web_server = [
+    "flow_logic",
+    "dep:axum",
+    "dep:hyper",
+    "dep:leptos_axum",
+    "dep:tokio",
+    "dep:tower",
+    "dep:tower-http",
+    "dep:tracing",
+    "leptos/ssr",
+    "leptos_meta/ssr",
+    "leptos_router/ssr",
+]
+
+# leptos
+# with ssr, the `main` function runs the server directly, without other CLI commands.
+ssr = ["web_server"]
+hydrate = [
+    "leptos/hydrate",
+    "leptos_meta/hydrate",
+    "leptos_router/hydrate",
+]
+
+[package.metadata.leptos]
+# See <https://github.com/leptos-rs/cargo-leptos/blob/main/README.md>
+# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
+output-name = "envman"
+# The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
+site-root = "target/web/envman"
+# The site-root relative folder where all compiled output (JS, WASM and CSS) is written
+# Defaults to pkg
+site-pkg-dir = "pkg"
+
+# The source style file. If it ends with _.sass_ or _.scss_ then it will be compiled by `dart-sass`
+# into CSS and processed by lightning css. When release is set, then it will also be minified.
+#
+# Optional. Env: LEPTOS_STYLE_FILE.
+# style-file = "../../target/web/envman/public/css/tailwind.css"
+tailwind-input-file = "src/web/tailwind.css"
+tailwind-config-file = "src/web/tailwind.config.js"
+
+# Assets source dir. All files found here will be copied and synchronized to site-root.
+# The assets-dir cannot have a sub directory with the same name/path as site-pkg-dir.
+#
+# Optional. Env: LEPTOS_ASSETS_DIR.
+# assets-dir = "assets"
+# The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
+site-addr = "127.0.0.1:7890"
+# The port to use for automatic reload monitoring
+reload-port = 7891
+# [Optional] Command to use when running end2end tests. It will run in the end2end dir.
+#   [Windows] for non-WSL use "npx.cmd playwright test"
+#   This binary name can be checked in Powershell with Get-Command npx
+# end2end-cmd = "npx playwright test"
+# end2end-dir = "end2end"
+#  The browserlist query used for optimizing the CSS.
+browserquery = "defaults"
+# Set by cargo-leptos watch when building with that tool. Controls whether autoreload JS will be included in the head
+watch = true
+# The environment Leptos will run in, usually either "DEV" or "PROD"
+env = "DEV"
+# The features to use when compiling the bin target
+#
+# Optional. Can be over-ridden with the command line parameter --bin-features
+bin-features = ["ssr"]
+
+# If the --no-default-features flag should be used when compiling the bin target
+#
+# Optional. Defaults to false.
+bin-default-features = false
+
+# The features to use when compiling the lib target
+#
+# Optional. Can be over-ridden with the command line parameter --lib-features
+lib-features = ["hydrate"]
+
+# If the --no-default-features flag should be used when compiling the lib target
+#
+# Optional. Defaults to false.
+lib-default-features = false

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -37,6 +37,13 @@ url = { version = "2.3.1", features = ["serde"] }
 urlencoding = "2.1.2"
 whoami = "1.4.0"
 
+# web_server
+axum = { version = "0.6.18", optional = true }
+dioxus = { version = "0.3.2", optional = true }
+dioxus-ssr = { version = "0.3.0", optional = true }
+hyper = { version = "0.14.26", optional = true }
+tower-http = { version = "0.4.0", optional = true, features = ["fs"] }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.2.1", features = ["derive"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
@@ -50,7 +57,7 @@ js-sys = "0.3.61"
 web-sys = "0.3.61"
 
 [features]
-default = []
+default = ["web_server"]
 error_reporting = [
     "peace/error_reporting",
     "peace_items/error_reporting",
@@ -60,4 +67,11 @@ output_json = ["peace/output_json"]
 output_progress = [
     "peace/output_progress",
     "peace_items/output_progress",
+]
+web_server = [
+    "dep:axum",
+    "dep:dioxus",
+    "dep:dioxus-ssr",
+    "dep:hyper",
+    "dep:tower-http",
 ]

--- a/examples/envman/src/flows/app_upload_flow.rs
+++ b/examples/envman/src/flows/app_upload_flow.rs
@@ -34,7 +34,7 @@ impl AppUploadFlow {
                     S3ObjectItem::<WebApp>::new(item_id!("s3_object")).into(),
                 ]);
 
-                graph_builder.add_edges([(a, b), (b, c)])?;
+                graph_builder.add_edges([(a, c), (b, c)])?;
                 graph_builder.build()
             };
 

--- a/examples/envman/src/lib.rs
+++ b/examples/envman/src/lib.rs
@@ -53,3 +53,6 @@ pub mod items;
 pub mod model;
 pub mod output;
 pub mod rt_model;
+
+#[cfg(feature = "web_server")]
+pub mod web;

--- a/examples/envman/src/lib.rs
+++ b/examples/envman/src/lib.rs
@@ -47,12 +47,16 @@
 //! envman diff dev demo
 //! ```
 
-pub mod cmds;
-pub mod flows;
-pub mod items;
-pub mod model;
-pub mod output;
-pub mod rt_model;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "flow_logic")] {
+        pub mod cmds;
+        pub mod flows;
+        pub mod items;
+        pub mod model;
+        pub mod output;
+        pub mod rt_model;
+    }
+}
 
 #[cfg(feature = "web_server")]
 pub mod web;

--- a/examples/envman/src/lib.rs
+++ b/examples/envman/src/lib.rs
@@ -58,5 +58,32 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "web_server")]
-pub mod web;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "web_components")] {
+        pub mod web;
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "web_components", feature = "hydrate"))] {
+        use wasm_bindgen::prelude::wasm_bindgen;
+        use leptos::*;
+
+        use crate::web::components::Home;
+
+        #[wasm_bindgen]
+        pub async fn hydrate() {
+
+            // initializes logging using the `log` crate
+            let _log = console_log::init_with_level(log::Level::Debug);
+            console_error_panic_hook::set_once();
+
+            leptos::mount_to_body(move |cx| {
+                view! {
+                    cx,
+                    <Home />
+                }
+            });
+        }
+    }
+}

--- a/examples/envman/src/main.rs
+++ b/examples/envman/src/main.rs
@@ -12,6 +12,9 @@ use envman::{
 use peace::rt_model::output::CliOutput;
 use tokio::io::Stdout;
 
+#[cfg(feature = "web_server")]
+use envman::web::WebServer;
+
 #[cfg(not(feature = "error_reporting"))]
 pub fn main() -> Result<(), EnvManError> {
     run()
@@ -151,6 +154,8 @@ async fn run_command(
         }
         EnvManCommand::Deploy => EnvDeployCmd::run(cli_output).await?,
         EnvManCommand::Clean => EnvCleanCmd::run(cli_output).await?,
+        #[cfg(feature = "web_server")]
+        EnvManCommand::Web { address, port } => WebServer::start(address, port).await?,
     }
 
     Ok::<_, EnvManError>(())

--- a/examples/envman/src/main.rs
+++ b/examples/envman/src/main.rs
@@ -1,162 +1,85 @@
-use clap::Parser;
-use envman::{
-    cmds::{
-        EnvCleanCmd, EnvDeployCmd, EnvDesiredCmd, EnvDiffCmd, EnvDiscoverCmd, EnvStatusCmd,
-        ProfileInitCmd, ProfileListCmd, ProfileShowCmd, ProfileSwitchCmd,
-    },
-    model::{
-        cli_args::{CliArgs, EnvManCommand, ProfileCommand},
-        EnvDiffSelection, EnvManError, ProfileSwitch,
-    },
-};
-use peace::rt_model::output::CliOutput;
-use tokio::io::Stdout;
+cfg_if::cfg_if! {
+    if #[cfg(all(feature = "flow_logic", not(feature = "ssr")))] {
+        // CLI app
 
-#[cfg(feature = "web_server")]
-use envman::web::WebServer;
+        use envman::model::EnvManError;
 
-#[cfg(not(feature = "error_reporting"))]
-pub fn main() -> Result<(), EnvManError> {
-    run()
-}
+        mod main_cli;
 
-#[cfg(feature = "error_reporting")]
-pub fn main() -> peace::miette::Result<(), peace::miette::Report> {
-    // Important to return `peace::miette::Report` instead of calling
-    // `IntoDiagnostic::intoDiagnostic` on the `Error`, as that does not present the
-    // diagnostic contextual information to the user.
-    //
-    // See <https://docs.rs/miette/latest/miette/trait.IntoDiagnostic.html#warning>.
+        #[cfg(not(feature = "error_reporting"))]
+        pub fn main() -> Result<(), EnvManError> {
+            main_cli::run()
+        }
 
-    // The explicit mapping for `PeaceRtError` appears to be necessary to display
-    // the diagnostic information. i.e. `miette` does not automatically delegate to
-    // the #[diagnostic_source].
-    //
-    // This is fixed by <https://github.com/zkat/miette/pull/170>.
+        #[cfg(feature = "error_reporting")]
+        pub fn main() -> peace::miette::Result<(), peace::miette::Report> {
+            // Important to return `peace::miette::Report` instead of calling
+            // `IntoDiagnostic::intoDiagnostic` on the `Error`, as that does not present the
+            // diagnostic contextual information to the user.
+            //
+            // See <https://docs.rs/miette/latest/miette/trait.IntoDiagnostic.html#warning>.
 
-    run().map_err(|envman_error| match envman_error {
-        EnvManError::PeaceItemFileDownload(err) => peace::miette::Report::from(err),
-        EnvManError::PeaceRtError(err) => peace::miette::Report::from(err),
-        other => peace::miette::Report::from(other),
-    })
-}
+            // The explicit mapping for `PeaceRtError` appears to be necessary to display
+            // the diagnostic information. i.e. `miette` does not automatically delegate to
+            // the #[diagnostic_source].
+            //
+            // This is fixed by <https://github.com/zkat/miette/pull/170>.
 
-pub fn run() -> Result<(), EnvManError> {
-    let CliArgs {
-        command,
-        fast,
-        format,
-        #[cfg(feature = "output_colorized")]
-        color,
-    } = CliArgs::parse();
-
-    let runtime = if fast {
-        tokio::runtime::Builder::new_multi_thread()
-    } else {
-        tokio::runtime::Builder::new_current_thread()
+            main_cli::run().map_err(|envman_error| match envman_error {
+                EnvManError::PeaceItemFileDownload(err) => peace::miette::Report::from(err),
+                EnvManError::PeaceRtError(err) => peace::miette::Report::from(err),
+                other => peace::miette::Report::from(other),
+            })
+        }
     }
-    .thread_name("main")
-    .thread_stack_size(3 * 1024 * 1024)
-    .enable_io()
-    .enable_time()
-    .build()
-    .map_err(EnvManError::TokioRuntimeInit)?;
-
-    runtime.block_on(async {
-        let mut cli_output = {
-            let mut builder = CliOutput::builder();
-            if let Some(format) = format {
-                builder = builder.with_outcome_format(format);
-            }
-            #[cfg(feature = "output_colorized")]
-            {
-                builder = builder.with_colorize(color);
-            }
-
-            builder.build()
+    else if #[cfg(all(feature = "flow_logic", feature = "ssr"))] {
+        // web server
+        use envman::{
+            model::EnvManError,
+            web::WebServer,
         };
 
-        match run_command(&mut cli_output, command).await {
-            Ok(()) => Ok(()),
-            Err(error) => envman::output::errors_present(&mut cli_output, &[error]).await,
-        }
-    })
-}
+        #[cfg(not(feature = "error_reporting"))]
+        pub fn main() -> Result<(), EnvManError> {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .thread_name("main")
+                .thread_stack_size(3 * 1024 * 1024)
+                .enable_io()
+                .enable_time()
+                .build()
+                .map_err(EnvManError::TokioRuntimeInit)?;
 
-async fn run_command(
-    cli_output: &mut CliOutput<Stdout>,
-    command: EnvManCommand,
-) -> Result<(), EnvManError> {
-    match command {
-        EnvManCommand::Init {
-            profile,
-            flow,
-            r#type,
-            slug,
-            version,
-            url,
-        } => {
-            ProfileInitCmd::run(
-                cli_output, profile, flow, r#type, &slug, &version, url, true,
-            )
-            .await?;
+            runtime.block_on(WebServer::start(Some(SocketAddr::from((ip_addr, port)))))
         }
-        EnvManCommand::Profile { command } => {
-            let command = command.unwrap_or(ProfileCommand::Show);
-            match command {
-                ProfileCommand::List => ProfileListCmd::run(cli_output).await?,
-                ProfileCommand::Show => ProfileShowCmd::run(cli_output).await?,
-            }
-        }
-        EnvManCommand::Switch {
-            profile,
-            create,
-            r#type,
-            slug,
-            version,
-            url,
-        } => {
-            let profile_switch = if create {
-                let Some(((env_type, slug), version)) = r#type.zip(slug).zip(version) else {
-                    unreachable!("`clap` should ensure `env_type`, `slug`, and `version` are \
-                        `Some` when `create` is `true`.");
-                };
-                ProfileSwitch::CreateNew {
-                    profile,
-                    env_type,
-                    slug,
-                    version,
-                    url,
-                }
-            } else {
-                ProfileSwitch::ToExisting { profile }
-            };
-            ProfileSwitchCmd::run(cli_output, profile_switch).await?
-        }
-        EnvManCommand::Discover => EnvDiscoverCmd::run(cli_output).await?,
-        EnvManCommand::Status => EnvStatusCmd::run(cli_output).await?,
-        EnvManCommand::Desired => EnvDesiredCmd::run(cli_output).await?,
-        EnvManCommand::Diff {
-            profile_a,
-            profile_b,
-        } => {
-            let env_diff_selection = profile_a
-                .zip(profile_b)
-                .map(
-                    |(profile_a, profile_b)| EnvDiffSelection::DiffProfilesCurrent {
-                        profile_a,
-                        profile_b,
-                    },
-                )
-                .unwrap_or(EnvDiffSelection::CurrentAndDesired);
 
-            EnvDiffCmd::run(cli_output, env_diff_selection).await?
+        #[cfg(feature = "error_reporting")]
+        pub fn main() -> peace::miette::Result<(), peace::miette::Report> {
+            // Important to return `peace::miette::Report` instead of calling
+            // `IntoDiagnostic::intoDiagnostic` on the `Error`, as that does not present the
+            // diagnostic contextual information to the user.
+            //
+            // See <https://docs.rs/miette/latest/miette/trait.IntoDiagnostic.html#warning>.
+
+            // The explicit mapping for `PeaceRtError` appears to be necessary to display
+            // the diagnostic information. i.e. `miette` does not automatically delegate to
+            // the #[diagnostic_source].
+            //
+            // This is fixed by <https://github.com/zkat/miette/pull/170>.
+
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .thread_name("main")
+                .thread_stack_size(3 * 1024 * 1024)
+                .enable_io()
+                .enable_time()
+                .build()
+                .map_err(EnvManError::TokioRuntimeInit)?;
+
+            runtime
+                .block_on(WebServer::start(None))
+                .map_err(peace::miette::Report::from)
         }
-        EnvManCommand::Deploy => EnvDeployCmd::run(cli_output).await?,
-        EnvManCommand::Clean => EnvCleanCmd::run(cli_output).await?,
-        #[cfg(feature = "web_server")]
-        EnvManCommand::Web { address, port } => WebServer::start(address, port).await?,
+    } else {
+        // web client logic
+        fn main() {}
     }
-
-    Ok::<_, EnvManError>(())
 }

--- a/examples/envman/src/main.rs
+++ b/examples/envman/src/main.rs
@@ -1,5 +1,5 @@
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "flow_logic", not(feature = "ssr")))] {
+    if #[cfg(feature = "cli")] {
         // CLI app
 
         use envman::model::EnvManError;
@@ -31,8 +31,7 @@ cfg_if::cfg_if! {
                 other => peace::miette::Report::from(other),
             })
         }
-    }
-    else if #[cfg(all(feature = "flow_logic", feature = "ssr"))] {
+    } else if #[cfg(feature = "ssr")] {
         // web server
         use envman::{
             model::EnvManError,
@@ -49,7 +48,7 @@ cfg_if::cfg_if! {
                 .build()
                 .map_err(EnvManError::TokioRuntimeInit)?;
 
-            runtime.block_on(WebServer::start(Some(SocketAddr::from((ip_addr, port)))))
+            runtime.block_on(WebServer::start(None))
         }
 
         #[cfg(feature = "error_reporting")]
@@ -78,8 +77,16 @@ cfg_if::cfg_if! {
                 .block_on(WebServer::start(None))
                 .map_err(peace::miette::Report::from)
         }
-    } else {
+    } else if #[cfg(feature = "csr")] {
         // web client logic
         fn main() {}
+    } else {
+        compile_error!(
+            r#"Please enable one of the following features:
+
+* "cli"
+* "ssr"
+* "csr"
+"#);
     }
 }

--- a/examples/envman/src/main_cli.rs
+++ b/examples/envman/src/main_cli.rs
@@ -1,0 +1,140 @@
+use std::net::SocketAddr;
+
+use clap::Parser;
+use envman::{
+    cmds::{
+        EnvCleanCmd, EnvDeployCmd, EnvDesiredCmd, EnvDiffCmd, EnvDiscoverCmd, EnvStatusCmd,
+        ProfileInitCmd, ProfileListCmd, ProfileShowCmd, ProfileSwitchCmd,
+    },
+    model::{
+        cli_args::{CliArgs, EnvManCommand, ProfileCommand},
+        EnvDiffSelection, EnvManError, ProfileSwitch,
+    },
+};
+use peace::rt_model::output::CliOutput;
+use tokio::io::Stdout;
+
+#[cfg(feature = "web_server")]
+use envman::web::WebServer;
+
+pub fn run() -> Result<(), EnvManError> {
+    let CliArgs {
+        command,
+        fast,
+        format,
+        #[cfg(feature = "output_colorized")]
+        color,
+    } = CliArgs::parse();
+
+    let runtime = if fast {
+        tokio::runtime::Builder::new_multi_thread()
+    } else {
+        tokio::runtime::Builder::new_current_thread()
+    }
+    .thread_name("main")
+    .thread_stack_size(3 * 1024 * 1024)
+    .enable_io()
+    .enable_time()
+    .build()
+    .map_err(EnvManError::TokioRuntimeInit)?;
+
+    runtime.block_on(async {
+        let mut cli_output = {
+            let mut builder = CliOutput::builder();
+            if let Some(format) = format {
+                builder = builder.with_outcome_format(format);
+            }
+            #[cfg(feature = "output_colorized")]
+            {
+                builder = builder.with_colorize(color);
+            }
+
+            builder.build()
+        };
+
+        match run_command(&mut cli_output, command).await {
+            Ok(()) => Ok(()),
+            Err(error) => envman::output::errors_present(&mut cli_output, &[error]).await,
+        }
+    })
+}
+
+async fn run_command(
+    cli_output: &mut CliOutput<Stdout>,
+    command: EnvManCommand,
+) -> Result<(), EnvManError> {
+    match command {
+        EnvManCommand::Init {
+            profile,
+            flow,
+            r#type,
+            slug,
+            version,
+            url,
+        } => {
+            ProfileInitCmd::run(
+                cli_output, profile, flow, r#type, &slug, &version, url, true,
+            )
+            .await?;
+        }
+        EnvManCommand::Profile { command } => {
+            let command = command.unwrap_or(ProfileCommand::Show);
+            match command {
+                ProfileCommand::List => ProfileListCmd::run(cli_output).await?,
+                ProfileCommand::Show => ProfileShowCmd::run(cli_output).await?,
+            }
+        }
+        EnvManCommand::Switch {
+            profile,
+            create,
+            r#type,
+            slug,
+            version,
+            url,
+        } => {
+            let profile_switch = if create {
+                let Some(((env_type, slug), version)) = r#type.zip(slug).zip(version) else {
+                    unreachable!("`clap` should ensure `env_type`, `slug`, and `version` are \
+                        `Some` when `create` is `true`.");
+                };
+                ProfileSwitch::CreateNew {
+                    profile,
+                    env_type,
+                    slug,
+                    version,
+                    url,
+                }
+            } else {
+                ProfileSwitch::ToExisting { profile }
+            };
+            ProfileSwitchCmd::run(cli_output, profile_switch).await?
+        }
+        EnvManCommand::Discover => EnvDiscoverCmd::run(cli_output).await?,
+        EnvManCommand::Status => EnvStatusCmd::run(cli_output).await?,
+        EnvManCommand::Desired => EnvDesiredCmd::run(cli_output).await?,
+        EnvManCommand::Diff {
+            profile_a,
+            profile_b,
+        } => {
+            let env_diff_selection = profile_a
+                .zip(profile_b)
+                .map(
+                    |(profile_a, profile_b)| EnvDiffSelection::DiffProfilesCurrent {
+                        profile_a,
+                        profile_b,
+                    },
+                )
+                .unwrap_or(EnvDiffSelection::CurrentAndDesired);
+
+            EnvDiffCmd::run(cli_output, env_diff_selection).await?
+        }
+        EnvManCommand::Deploy => EnvDeployCmd::run(cli_output).await?,
+        EnvManCommand::Clean => EnvCleanCmd::run(cli_output).await?,
+        #[cfg(feature = "web_server")]
+        EnvManCommand::Web { address, port } => {
+            WebServer::start(Some(SocketAddr::from((address, port)))).await?
+        }
+    }
+
+    Ok::<_, EnvManError>(())
+}

--- a/examples/envman/src/model/cli_args.rs
+++ b/examples/envman/src/model/cli_args.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "web_server")]
+use std::net::IpAddr;
+
 use clap::{Parser, Subcommand, ValueHint};
 use peace::{cfg::Profile, rt_model::output::OutputFormat};
 use semver::Version;
@@ -116,6 +119,18 @@ pub enum EnvManCommand {
     Deploy,
     /// Cleans the current environment.
     Clean,
+    /// Runs `envman` as a web server.
+    #[cfg(feature = "web_server")]
+    Web {
+        /// The address to bind to, defaults to `127.0.0.1`.
+        ///
+        /// If you want to listen on all interfaces, use `0.0.0.0`.
+        #[arg(long, default_value = "127.0.0.1", value_hint(ValueHint::Other))]
+        address: IpAddr,
+        /// Port to listen on, defaults to `7890`.
+        #[arg(short, long, default_value = "7890", value_hint(ValueHint::Other))]
+        port: u16,
+    },
 }
 
 #[derive(Subcommand)]

--- a/examples/envman/src/model/envman_error.rs
+++ b/examples/envman/src/model/envman_error.rs
@@ -154,4 +154,18 @@ pub enum EnvManError {
     // === Scaffolding errors === //
     #[error("Failed to initialize tokio runtime.")]
     TokioRuntimeInit(#[source] std::io::Error),
+
+    // === Web Server errors === //
+    /// Web server ended due to an error.
+    #[cfg(feature = "web_server")]
+    #[error("Web server ended due to an error.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(code(envman::web_server_serve),)
+    )]
+    WebServerServe {
+        /// Underlying error.
+        #[source]
+        error: hyper::Error,
+    },
 }

--- a/examples/envman/src/model/envman_error.rs
+++ b/examples/envman/src/model/envman_error.rs
@@ -157,7 +157,7 @@ pub enum EnvManError {
 
     // === Web Server errors === //
     /// Web server ended due to an error.
-    #[cfg(feature = "web_server")]
+    #[cfg(feature = "ssr")]
     #[error("Web server ended due to an error.")]
     #[cfg_attr(
         feature = "error_reporting",
@@ -170,7 +170,7 @@ pub enum EnvManError {
     },
 
     /// Failed to join thread that rendered web server home page.
-    #[cfg(feature = "web_server")]
+    #[cfg(feature = "ssr")]
     #[error("Failed to join thread that rendered web server home page.")]
     #[cfg_attr(
         feature = "error_reporting",

--- a/examples/envman/src/model/envman_error.rs
+++ b/examples/envman/src/model/envman_error.rs
@@ -168,4 +168,17 @@ pub enum EnvManError {
         #[source]
         error: hyper::Error,
     },
+
+    /// Failed to join thread that rendered web server home page.
+    #[cfg(feature = "web_server")]
+    #[error("Failed to join thread that rendered web server home page.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(code(envman::web_server_render_join))
+    )]
+    WebServerRenderJoin {
+        /// Underlying error.
+        #[source]
+        error: tokio::task::JoinError,
+    },
 }

--- a/examples/envman/src/web.rs
+++ b/examples/envman/src/web.rs
@@ -1,4 +1,6 @@
 //! Runs `envman` as a web application.
+//!
+//! See <https://leptos-rs.github.io/leptos> for the leptos usage guide.
 
 pub use self::flow_dot_renderer::FlowDotRenderer;
 

--- a/examples/envman/src/web.rs
+++ b/examples/envman/src/web.rs
@@ -1,7 +1,17 @@
 //! Runs `envman` as a web application.
 
-pub use self::{flow_dot_renderer::FlowDotRenderer, web_server::WebServer};
+pub use self::flow_dot_renderer::FlowDotRenderer;
 
-mod components;
+pub mod components;
+
 mod flow_dot_renderer;
-mod web_server;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "ssr")] {
+        pub use self::web_server::WebServer;
+
+        mod web_server;
+    } else if #[cfg(feature = "csr")] {
+        pub mod client;
+    }
+}

--- a/examples/envman/src/web.rs
+++ b/examples/envman/src/web.rs
@@ -1,0 +1,6 @@
+//! Runs `envman` as a web application.
+
+pub use self::web_server::WebServer;
+
+mod components;
+mod web_server;

--- a/examples/envman/src/web.rs
+++ b/examples/envman/src/web.rs
@@ -1,6 +1,7 @@
 //! Runs `envman` as a web application.
 
-pub use self::web_server::WebServer;
+pub use self::{flow_dot_renderer::FlowDotRenderer, web_server::WebServer};
 
 mod components;
+mod flow_dot_renderer;
 mod web_server;

--- a/examples/envman/src/web/client.rs
+++ b/examples/envman/src/web/client.rs
@@ -1,0 +1,22 @@
+cfg_if::cfg_if! {
+    if #[cfg(feature = "hydrate")] {
+        use wasm_bindgen::prelude::wasm_bindgen;
+        use leptos::*;
+
+        // use crate::{flows::AppUploadFlow, web::components::Home};
+
+        #[wasm_bindgen]
+        pub async fn hydrate() {
+            // initializes logging using the `log` crate
+            let _log = console_log::init_with_level(log::Level::Debug);
+            console_error_panic_hook::set_once();
+
+            leptos::mount_to_body(move |cx| {
+                view! {
+                    cx,
+                    <div>rara</div>
+                }
+            });
+        }
+    }
+}

--- a/examples/envman/src/web/components.rs
+++ b/examples/envman/src/web/components.rs
@@ -1,5 +1,14 @@
-#![allow(non_snake_case)]
+#![allow(non_snake_case)] // Components in rsx are all PascalCase.
 
-pub use self::home::Home;
+//! Components for rendering a flow.
+//!
+//! See <https://github.com/DioxusLabs/dioxus/blob/master/packages/html/src/elements.rs> for the
+//! elements that can be placed in the `rsx!` macro calls.
 
+pub use self::{
+    flow_graph::{FlowGraph, FlowGraphProps},
+    home::{Home, HomeProps},
+};
+
+mod flow_graph;
 mod home;

--- a/examples/envman/src/web/components.rs
+++ b/examples/envman/src/web/components.rs
@@ -5,10 +5,7 @@
 //! See <https://github.com/DioxusLabs/dioxus/blob/master/packages/html/src/elements.rs> for the
 //! elements that can be placed in the `rsx!` macro calls.
 
-pub use self::{
-    flow_graph::{FlowGraph, FlowGraphProps},
-    home::{Home, HomeProps},
-};
+pub use self::{flow_graph::FlowGraph, home::Home};
 
 mod flow_graph;
 mod home;

--- a/examples/envman/src/web/components.rs
+++ b/examples/envman/src/web/components.rs
@@ -7,5 +7,8 @@
 
 pub use self::{flow_graph::FlowGraph, home::Home};
 
+#[cfg(feature = "ssr")]
+pub use self::flow_graph::FlowGraphSrc;
+
 mod flow_graph;
 mod home;

--- a/examples/envman/src/web/components.rs
+++ b/examples/envman/src/web/components.rs
@@ -1,0 +1,5 @@
+#![allow(non_snake_case)]
+
+pub use self::home::Home;
+
+mod home;

--- a/examples/envman/src/web/components.rs
+++ b/examples/envman/src/web/components.rs
@@ -1,9 +1,6 @@
-#![allow(non_snake_case)] // Components in rsx are all PascalCase.
+#![allow(non_snake_case)] // Components are all PascalCase.
 
 //! Components for rendering a flow.
-//!
-//! See <https://github.com/DioxusLabs/dioxus/blob/master/packages/html/src/elements.rs> for the
-//! elements that can be placed in the `rsx!` macro calls.
 
 pub use self::{flow_graph::FlowGraph, home::Home};
 

--- a/examples/envman/src/web/components/flow_graph.rs
+++ b/examples/envman/src/web/components/flow_graph.rs
@@ -1,45 +1,40 @@
-use dioxus::prelude::*;
+use leptos::{component, create_signal, view, IntoView, Scope, SignalGet, SignalUpdate};
 use peace::rt_model::Flow;
 
 use crate::{model::EnvManError, web::FlowDotRenderer};
 
-/// Parameters for the flow graph.
-#[derive(PartialEq, Props)]
-pub struct FlowGraphProps {
-    pub flow: Flow<EnvManError>,
-}
-
 /// Renders the flow graph.
-pub fn FlowGraph(cx: Scope<FlowGraphProps>) -> Element {
+#[component]
+pub fn FlowGraph(cx: Scope, flow: Flow<EnvManError>) -> impl IntoView {
     // use peace::rt_model::fn_graph::daggy::petgraph::dot::{Config, Dot};
     // let dot_source = Dot::with_config(cx.props.flow.graph().graph(),
     // &[Config::EdgeNoLabel]);
     let dot_source = {
         let flow_dot_renderer = FlowDotRenderer::new();
-        flow_dot_renderer.dot(&cx.props.flow)
+        flow_dot_renderer.dot(&flow)
     };
-    let mut num = use_state(cx, || 0);
+    let (count, set_count) = create_signal(cx, 0);
 
-    cx.render(rsx! {
-        div {
-            class: "flex items-center justify-center",
-            div {
-                id: "flow_dot_diagram",
-
-                "hello axum! {num}"
-                button { onclick: move |_| num += 1, "Increment" }
-            }
-        }
-        script {
-            r#type: "module",
+    view! {
+        cx,
+        <div class="flex items-center justify-center">
+            <div id="flow_dot_diagram"></div>
+            <div>
+                "hello leptos!" { move || count.get() }
+                <button on:click=move |_| { set_count.update(|n| *n += 1); }>
+                    "Increment me!"
+                </button>
+            </div>
+        </div>
+        <script type="module">
             "\
-            import {{ Graphviz }} from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
+            import { Graphviz } from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
             \n\
             const graphviz = await Graphviz.load();\n\
-            const dot_source = `{dot_source}`;\n\
+            const dot_source = `" { dot_source }"`;\n\
             document.getElementById(\"flow_dot_diagram\").innerHTML =\n\
             graphviz.layout(dot_source, \"svg\", \"dot\");\n\
             "
-        }
-    })
+        </script>
+    }
 }

--- a/examples/envman/src/web/components/flow_graph.rs
+++ b/examples/envman/src/web/components/flow_graph.rs
@@ -1,40 +1,99 @@
-use leptos::{component, create_signal, view, IntoView, Scope, SignalGet, SignalUpdate};
-use peace::rt_model::Flow;
-
-use crate::{model::EnvManError, web::FlowDotRenderer};
+use leptos::{
+    component, create_signal, server_fn, view, IntoView, Scope, ServerFnError, SignalGet,
+    SignalUpdate, Transition,
+};
 
 /// Renders the flow graph.
 #[component]
-pub fn FlowGraph(cx: Scope, flow: Flow<EnvManError>) -> impl IntoView {
-    // use peace::rt_model::fn_graph::daggy::petgraph::dot::{Config, Dot};
-    // let dot_source = Dot::with_config(cx.props.flow.graph().graph(),
-    // &[Config::EdgeNoLabel]);
-    let dot_source = {
-        let flow_dot_renderer = FlowDotRenderer::new();
-        flow_dot_renderer.dot(&flow)
-    };
+pub fn FlowGraph(cx: Scope) -> impl IntoView {
     let (count, set_count) = create_signal(cx, 0);
+
+    let dot_source_resource = leptos::create_resource(
+        cx,
+        || (),
+        move |()| async move { flow_graph_src(cx).await.unwrap() },
+    );
+    let dot_source_result = {
+        move || {
+            let dot_source = dot_source_resource
+                .read(cx)
+                .unwrap_or_else(|| String::from("digraph {}"));
+
+            let script_src = format!(
+                "\
+                import {{ Graphviz }} from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
+                \n\
+                const graphviz = await Graphviz.load();\n\
+                const dot_source = `{dot_source}`;\n\
+                document.getElementById(\"flow_dot_diagram\").innerHTML =\n\
+                graphviz.layout(dot_source, \"svg\", \"dot\");\n\
+                "
+            );
+
+            view! {
+                cx,
+                <script type="module">
+                { script_src }
+                </script>
+            }
+        }
+    };
 
     view! {
         cx,
         <div class="flex items-center justify-center">
             <div id="flow_dot_diagram"></div>
+            <br />
             <div>
                 "hello leptos!" { move || count.get() }
+                <br />
                 <button on:click=move |_| { set_count.update(|n| *n += 1); }>
                     "Increment me!"
                 </button>
             </div>
         </div>
-        <script type="module">
-            "\
-            import { Graphviz } from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
-            \n\
-            const graphviz = await Graphviz.load();\n\
-            const dot_source = `" { dot_source }"`;\n\
-            document.getElementById(\"flow_dot_diagram\").innerHTML =\n\
-            graphviz.layout(dot_source, \"svg\", \"dot\");\n\
-            "
-        </script>
+        <Transition fallback=move || view! {cx, <p>"Loading graph..."</p> }>
+        { dot_source_result }
+        </Transition>
+        // Client side rendering, if we know what flow we have.
+        //
+        // This doesn't work for us because:
+        //
+        // * Loading a `flow` is `async`.
+        // * Component functions are `sync`.
+        // * Loading a resource using `leptos::create_resource` returns the loaded value between
+        //   `<!-- leptos -->` tags.
+        // * Such tags cannot be children of a `<script />` element.
+        //
+        // ```html
+        // <script type="module">
+        //     "\
+        //     import {{ Graphviz }} from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
+        //     \n\
+        //     const graphviz = await Graphviz.load();\n\
+        //     const dot_source = `" { dot_source } "`;\n\
+        //     document.getElementById(\"flow_dot_diagram\").innerHTML =\n\
+        //     graphviz.layout(dot_source, \"svg\", \"dot\");\n\
+        //     "
+        // </script>
+        // ```
     }
+}
+
+#[cfg(feature = "hydrate")]
+use leptos::server_fn::ServerFn;
+
+#[leptos::server(FlowGraphSrc, "/flow_graph")]
+pub async fn flow_graph_src(_cx: Scope) -> Result<String, ServerFnError> {
+    use crate::{flows::AppUploadFlow, web::FlowDotRenderer};
+    let flow = AppUploadFlow::flow()
+        .await
+        .map_err(|envman_error| ServerFnError::ServerError(format!("{}", envman_error)))?;
+
+    // use peace::rt_model::fn_graph::daggy::petgraph::dot::{Config, Dot};
+    // let dot_source = Dot::with_config(cx.props.flow.graph().graph(),
+    // &[Config::EdgeNoLabel]);
+
+    let flow_dot_renderer = FlowDotRenderer::new();
+    Ok(flow_dot_renderer.dot(&flow))
 }

--- a/examples/envman/src/web/components/flow_graph.rs
+++ b/examples/envman/src/web/components/flow_graph.rs
@@ -1,0 +1,41 @@
+use dioxus::prelude::*;
+use peace::rt_model::Flow;
+
+use crate::{model::EnvManError, web::FlowDotRenderer};
+
+/// Parameters for the flow graph.
+#[derive(PartialEq, Props)]
+pub struct FlowGraphProps {
+    pub flow: Flow<EnvManError>,
+}
+
+/// Renders the flow graph.
+pub fn FlowGraph(cx: Scope<FlowGraphProps>) -> Element {
+    // use peace::rt_model::fn_graph::daggy::petgraph::dot::{Config, Dot};
+    // let dot_source = Dot::with_config(cx.props.flow.graph().graph(),
+    // &[Config::EdgeNoLabel]);
+    let dot_source = {
+        let flow_dot_renderer = FlowDotRenderer::new();
+        flow_dot_renderer.dot(&cx.props.flow)
+    };
+    let mut num = use_state(cx, || 0);
+
+    cx.render(rsx! {
+        div {
+            id: "flow_dot_diagram",
+            "hello axum! {num}"
+            button { onclick: move |_| num += 1, "Increment" }
+        }
+        script {
+            r#type: "module",
+            "\
+            import {{ Graphviz }} from \"https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphviz.js\";\n\
+            \n\
+            const graphviz = await Graphviz.load();\n\
+            const dot_source = `{dot_source}`;\n\
+            document.getElementById(\"flow_dot_diagram\").innerHTML =\n\
+            graphviz.layout(dot_source, \"svg\", \"dot\");\n\
+            "
+        }
+    })
+}

--- a/examples/envman/src/web/components/flow_graph.rs
+++ b/examples/envman/src/web/components/flow_graph.rs
@@ -22,9 +22,13 @@ pub fn FlowGraph(cx: Scope<FlowGraphProps>) -> Element {
 
     cx.render(rsx! {
         div {
-            id: "flow_dot_diagram",
-            "hello axum! {num}"
-            button { onclick: move |_| num += 1, "Increment" }
+            class: "flex items-center justify-center",
+            div {
+                id: "flow_dot_diagram",
+
+                "hello axum! {num}"
+                button { onclick: move |_| num += 1, "Increment" }
+            }
         }
         script {
             r#type: "module",

--- a/examples/envman/src/web/components/home.rs
+++ b/examples/envman/src/web/components/home.rs
@@ -1,27 +1,26 @@
-use std::net::SocketAddr;
+use leptos::{component, create_signal, view, IntoView, Scope, SignalGet};
+use leptos_meta::{Link, Stylesheet};
+use leptos_router::{Route, Router, Routes};
+use peace::rt_model::Flow;
 
-use dioxus::prelude::*;
+use crate::{model::EnvManError, web::components::FlowGraph};
 
-/// Parameters for the homepage.
-#[derive(PartialEq, Props)]
-pub struct HomeProps {
-    pub socket_addr: SocketAddr,
-}
-
-pub fn Home(cx: Scope<HomeProps>) -> Element {
-    let socket_addr = &cx.props.socket_addr;
-    cx.render(rsx!(
-        head {
-            link {
-                href: "/public/css/tailwind.css",
-                rel: "stylesheet",
-            }
-        }
-        body {
-            div {
-                id: "main",
-            }
-            dioxus_liveview::interpreter_glue(&format!("ws://{socket_addr}/ws"))
-        }
-    ))
+#[component]
+pub fn Home(cx: Scope, flow: Flow<EnvManError>) -> impl IntoView {
+    let (flow, _set_flow) = create_signal(cx, flow);
+    view! {
+        cx,
+        <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
+        <Stylesheet id="tailwind" href="/pkg/envman.css"/>
+        <Router>
+            <main>
+                <Routes>
+                    <Route path="" view=move |cx| view! {
+                        cx,
+                        <FlowGraph flow=flow.get() />
+                    }/>
+                </Routes>
+            </main>
+        </Router>
+    }
 }

--- a/examples/envman/src/web/components/home.rs
+++ b/examples/envman/src/web/components/home.rs
@@ -1,13 +1,22 @@
+use std::net::SocketAddr;
+
 use dioxus::prelude::*;
 
-pub fn Home(cx: Scope) -> Element {
+/// Parameters for the homepage.
+#[derive(PartialEq, Props)]
+pub struct HomeProps {
+    pub socket_addr: SocketAddr,
+}
+
+pub fn Home(cx: Scope<HomeProps>) -> Element {
+    let socket_addr = &cx.props.socket_addr;
     cx.render(rsx!(
         head {}
         body {
-            section {
-                class: "p-10",
-                "Home page"
+            div {
+                id: "main",
             }
+            dioxus_liveview::interpreter_glue(&format!("ws://{socket_addr}/ws"))
         }
     ))
 }

--- a/examples/envman/src/web/components/home.rs
+++ b/examples/envman/src/web/components/home.rs
@@ -1,13 +1,14 @@
-use leptos::{component, create_signal, view, IntoView, Scope, SignalGet};
-use leptos_meta::{Link, Stylesheet};
+use leptos::{component, view, IntoView, Scope};
+use leptos_meta::{provide_meta_context, Link, Stylesheet};
 use leptos_router::{Route, Router, Routes};
-use peace::rt_model::Flow;
 
-use crate::{model::EnvManError, web::components::FlowGraph};
+use crate::web::components::FlowGraph;
 
 #[component]
-pub fn Home(cx: Scope, flow: Flow<EnvManError>) -> impl IntoView {
-    let (flow, _set_flow) = create_signal(cx, flow);
+pub fn Home(cx: Scope) -> impl IntoView {
+    // Provides context that manages stylesheets, titles, meta tags, etc.
+    provide_meta_context(cx);
+
     view! {
         cx,
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
@@ -17,7 +18,7 @@ pub fn Home(cx: Scope, flow: Flow<EnvManError>) -> impl IntoView {
                 <Routes>
                     <Route path="" view=move |cx| view! {
                         cx,
-                        <FlowGraph flow=flow.get() />
+                        <FlowGraph />
                     }/>
                 </Routes>
             </main>

--- a/examples/envman/src/web/components/home.rs
+++ b/examples/envman/src/web/components/home.rs
@@ -1,0 +1,13 @@
+use dioxus::prelude::*;
+
+pub fn Home(cx: Scope) -> Element {
+    cx.render(rsx!(
+        head {}
+        body {
+            section {
+                class: "p-10",
+                "Home page"
+            }
+        }
+    ))
+}

--- a/examples/envman/src/web/components/home.rs
+++ b/examples/envman/src/web/components/home.rs
@@ -11,7 +11,12 @@ pub struct HomeProps {
 pub fn Home(cx: Scope<HomeProps>) -> Element {
     let socket_addr = &cx.props.socket_addr;
     cx.render(rsx!(
-        head {}
+        head {
+            link {
+                href: "/public/css/tailwind.css",
+                rel: "stylesheet",
+            }
+        }
         body {
             div {
                 id: "main",

--- a/examples/envman/src/web/flow_dot_renderer.rs
+++ b/examples/envman/src/web/flow_dot_renderer.rs
@@ -121,13 +121,22 @@ impl FlowDotRenderer {
 
     fn item_cluster(&self, item_id: &ItemId) -> String {
         let plain_text_color = self.plain_text_color;
+        let classes = "\
+            [&>ellipse]:fill-slate-300 \
+            [&>ellipse]:stroke-1 \
+            [&>ellipse]:stroke-slate-600 \
+            [&>ellipse]:hover:fill-slate-200 \
+            [&>ellipse]:hover:stroke-slate-600 \
+            [&>ellipse]:hover:stroke-2 \
+            cursor-pointer \
+        ";
         format!(
             r#"
             subgraph cluster_{item_id} {{
-                {item_id} [label = ""]
+                {item_id} [label = "" class = "{classes}"]
                 {item_id}_text [
                     shape="plain"
-                    style=""\
+                    style=""
                     fontcolor="{plain_text_color}"
                     label = <<table
                         border="0"

--- a/examples/envman/src/web/flow_dot_renderer.rs
+++ b/examples/envman/src/web/flow_dot_renderer.rs
@@ -148,3 +148,9 @@ impl FlowDotRenderer {
         format!(r#"{src_item_id} -> {target_item_id} [minlen = 9]"#)
     }
 }
+
+impl Default for FlowDotRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/examples/envman/src/web/flow_dot_renderer.rs
+++ b/examples/envman/src/web/flow_dot_renderer.rs
@@ -69,10 +69,13 @@ impl FlowDotRenderer {
 
     fn graph_attrs(&self) -> String {
         let plain_text_color = self.plain_text_color;
+        // Note: `margin` is set to 0.1 because some text lies outside the viewport.
+        // This may be due to incorrect width calculation for emoji characters, which
+        // GraphViz falls back to the space character width.
         format!(
             "\
                 graph [\n\
-                    margin    = 0.0\n\
+                    margin    = 0.1\n\
                     penwidth  = 0\n\
                     nodesep   = 0.0\n\
                     ranksep   = 0.02\n\

--- a/examples/envman/src/web/flow_dot_renderer.rs
+++ b/examples/envman/src/web/flow_dot_renderer.rs
@@ -79,6 +79,7 @@ impl FlowDotRenderer {
                     bgcolor   = \"transparent\"\n\
                     fontname  = \"helvetica\"\n\
                     fontcolor = \"{plain_text_color}\"\n\
+                    splines   = line\n\
                     rankdir   = LR\n\
                 ]\n\
             "

--- a/examples/envman/src/web/flow_dot_renderer.rs
+++ b/examples/envman/src/web/flow_dot_renderer.rs
@@ -1,0 +1,150 @@
+use peace::{cfg::ItemId, rt_model::Flow};
+
+/// Renders a `Flow` as a GraphViz Dot diagram.
+///
+/// This is currently a mashed together implementation. A proper implementation
+/// would require investigation into:
+///
+/// * Whether colours and border sizes should be part of a theme object that we
+///   take in.
+/// * Whether colours and border sizes can be configured through CSS classes,
+///   and within the generated dot source, we only apply those classes.
+#[derive(Debug)]
+pub struct FlowDotRenderer {
+    edge_color: &'static str,
+    node_text_color: &'static str,
+    plain_text_color: &'static str,
+}
+
+impl FlowDotRenderer {
+    pub fn new() -> Self {
+        Self {
+            edge_color: "#7f7f7f",
+            node_text_color: "#111111",
+            plain_text_color: "#7f7f7f",
+        }
+    }
+
+    pub fn dot<E>(&self, flow: &Flow<E>) -> String
+    where
+        E: 'static,
+    {
+        let graph_attrs = self.graph_attrs();
+        let node_attrs = self.node_attrs();
+        let edge_attrs = self.edge_attrs();
+
+        let item_clusters = flow
+            .graph()
+            .iter()
+            .map(|item| self.item_cluster(item.id()))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        let edges = flow
+            .graph()
+            .raw_edges()
+            .iter()
+            .map(|edge| {
+                let src_item = &flow.graph()[edge.source()];
+                let src_item_id = src_item.id();
+                let target_item = &flow.graph()[edge.target()];
+                let target_item_id = target_item.id();
+                self.edge(src_item_id, target_item_id)
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        format!(
+            "digraph G {{
+                {graph_attrs}
+                {node_attrs}
+                {edge_attrs}
+
+                {item_clusters}
+
+                {edges}
+            }}"
+        )
+    }
+
+    fn graph_attrs(&self) -> String {
+        let plain_text_color = self.plain_text_color;
+        format!(
+            "\
+                graph [\n\
+                    margin    = 0.0\n\
+                    penwidth  = 0\n\
+                    nodesep   = 0.0\n\
+                    ranksep   = 0.02\n\
+                    bgcolor   = \"transparent\"\n\
+                    fontname  = \"helvetica\"\n\
+                    fontcolor = \"{plain_text_color}\"\n\
+                    rankdir   = LR\n\
+                ]\n\
+            "
+        )
+    }
+
+    fn node_attrs(&self) -> String {
+        let node_text_color = self.node_text_color;
+        format!(
+            "\
+                node [\n\
+                    fontcolor = \"{node_text_color}\"\n\
+                    fontname  = \"monospace\"\n\
+                    fontsize  = 12\n\
+                    shape     = \"circle\"\n\
+                    style     = \"filled\"\n\
+                    width     = 0.3\n\
+                    height    = 0.3\n\
+                    margin    = 0.04\n\
+                    color     = \"#9999aa\"\n\
+                    fillcolor = \"#ddddf5\"\n\
+                ]\n\
+            "
+        )
+    }
+
+    fn edge_attrs(&self) -> String {
+        let edge_color = self.edge_color;
+        let plain_text_color = self.plain_text_color;
+        format!(
+            "\
+                edge [\n\
+                    arrowsize = 0.7\n\
+                    color     = \"{edge_color}\"\n\
+                    fontcolor = \"{plain_text_color}\"\n\
+                ]\n\
+            "
+        )
+    }
+
+    fn item_cluster(&self, item_id: &ItemId) -> String {
+        let plain_text_color = self.plain_text_color;
+        format!(
+            r#"
+            subgraph cluster_{item_id} {{
+                {item_id} [label = ""]
+                {item_id}_text [
+                    shape="plain"
+                    style=""\
+                    fontcolor="{plain_text_color}"
+                    label = <<table
+                        border="0"
+                        cellborder="0"
+                        cellpadding="0">
+                        <tr>
+                            <td><font point-size="15">📥</font></td>
+                            <td balign="left">{item_id}</td>
+                        </tr>
+                    </table>>
+                ]
+            }}
+        "#
+        )
+    }
+
+    fn edge(&self, src_item_id: &ItemId, target_item_id: &ItemId) -> String {
+        format!(r#"{src_item_id} -> {target_item_id} [minlen = 9]"#)
+    }
+}

--- a/examples/envman/src/web/tailwind.config.js
+++ b/examples/envman/src/web/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    // Relative to workspace root.
+    'examples/envman/**/*.rs',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/examples/envman/src/web/tailwind.css
+++ b/examples/envman/src/web/tailwind.css
@@ -1,0 +1,5 @@
+@config "./tailwind.config.js";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/envman/src/web/tailwind.css
+++ b/examples/envman/src/web/tailwind.css
@@ -1,5 +1,3 @@
-@config "./tailwind.config.js";
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/examples/envman/src/web/web_server.rs
+++ b/examples/envman/src/web/web_server.rs
@@ -1,0 +1,48 @@
+use std::net::{IpAddr, SocketAddr};
+
+use axum::{response::Html, routing::get, Router};
+use dioxus::prelude::VirtualDom;
+use tower_http::services::ServeDir;
+
+use crate::{model::EnvManError, web::components::Home};
+
+/// Web server that responds to `envman` requests.
+#[derive(Debug)]
+pub struct WebServer {}
+
+/// See <https://github.com/DioxusLabs/example-projects/blob/master/ecommerce-site/src/main.rs>
+/// for referenced code.
+
+impl WebServer {
+    /// Starts the web server.
+    pub async fn start(ip_addr: IpAddr, port: u16) -> Result<(), EnvManError> {
+        let addr = SocketAddr::from((ip_addr, port));
+
+        let app = Router::new()
+            // serve the public directory
+            .nest_service("/public", ServeDir::new("public"))
+            // serve the SSR rendered homepage
+            .route("/", get(root));
+
+        println!("listening on http://{}", addr);
+        println!("- Route available on http://{}", addr);
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .map_err(|error| EnvManError::WebServerServe { error })
+    }
+}
+
+// Just render a simple page directly from the request
+async fn root() -> Html<String> {
+    // The root page blocks on futures so we need to render it in a spawn_blocking
+    // task
+    tokio::task::spawn_blocking(move || async move {
+        let mut app = VirtualDom::new(Home);
+        let _ = app.rebuild();
+        Html(dioxus_ssr::render(&app))
+    })
+    .await
+    .unwrap()
+    .await
+}

--- a/examples/envman/src/web/web_server.rs
+++ b/examples/envman/src/web/web_server.rs
@@ -36,7 +36,6 @@ impl WebServer {
                 ])),
             )
             // serve the SSR rendered homepage
-            // The WebSocket route is what Dioxus uses to communicate with the browser
             .leptos_routes(
                 leptos_options.clone(),
                 routes,

--- a/examples/envman/src/web/web_server.rs
+++ b/examples/envman/src/web/web_server.rs
@@ -51,7 +51,7 @@ impl WebServer {
             );
 
         let (Ok(()) | Err(_)) = tokio::io::stderr()
-            .write_all(format!("listening on http://{}", socket_addr).as_bytes())
+            .write_all(format!("listening on http://{}\n", socket_addr).as_bytes())
             .await;
         axum::Server::bind(&socket_addr)
             .serve(app.into_make_service())

--- a/examples/envman/src/web/web_server.rs
+++ b/examples/envman/src/web/web_server.rs
@@ -1,87 +1,62 @@
-use std::net::{IpAddr, SocketAddr};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
-use axum::{extract::WebSocketUpgrade, response::Html, routing::get, Router};
-use dioxus::prelude::VirtualDom;
+use axum::{Extension, Router};
+use leptos::view;
+use leptos_axum::LeptosRoutes;
 use tokio::io::AsyncWriteExt;
 use tower_http::services::ServeDir;
 
-use crate::{
-    flows::AppUploadFlow,
-    model::EnvManError,
-    web::components::{FlowGraph, FlowGraphProps, Home, HomeProps},
-};
+use crate::{flows::AppUploadFlow, model::EnvManError, web::components::Home};
 
 /// Web server that responds to `envman` requests.
 #[derive(Debug)]
 pub struct WebServer {}
 
-/// See <https://github.com/DioxusLabs/example-projects/blob/master/ecommerce-site/src/main.rs>
-/// for referenced code.
-
 impl WebServer {
     /// Starts the web server.
-    pub async fn start(ip_addr: IpAddr, port: u16) -> Result<(), EnvManError> {
-        let socket_addr = SocketAddr::from((ip_addr, port));
+    pub async fn start(socket_addr: Option<SocketAddr>) -> Result<(), EnvManError> {
+        let flow = AppUploadFlow::flow().await?;
 
-        let view = dioxus_liveview::LiveViewPool::new();
+        // Setting this to None means we'll be using cargo-leptos and its env vars
+        let conf = leptos::get_configuration(None).await.unwrap();
+        let leptos_options = conf.leptos_options;
+        let socket_addr = socket_addr.unwrap_or(leptos_options.site_addr);
+        let routes = leptos_axum::generate_route_list(|cx| view! { cx, <Home flow=flow /> }).await;
 
+        let flow = AppUploadFlow::flow().await?;
         let app = Router::new()
-            // serve the public directory
-            .nest_service("/public", ServeDir::new("public"))
+            // serve the pkg directory
+            .nest_service(
+                "/pkg",
+                ServeDir::new(PathBuf::from_iter([
+                    leptos_options.site_root.as_str(),
+                    leptos_options.site_pkg_dir.as_str(),
+                ])),
+            )
             // serve the SSR rendered homepage
-            .route("/", get(move || root(socket_addr)))
             // The WebSocket route is what Dioxus uses to communicate with the browser
-            .route(
-                "/ws",
-                get(move |ws: WebSocketUpgrade| async move {
-                    ws.on_upgrade(move |socket| async move {
-                        let flow = AppUploadFlow::flow().await.unwrap();
-
-                        // When the WebSocket is upgraded, launch the LiveView with the app
-                        // component
-                        _ = view
-                            .launch_with_props(
-                                dioxus_liveview::axum_socket(socket),
-                                FlowGraph,
-                                FlowGraphProps { flow },
-                            )
-                            .await;
-                    })
-                }),
-            );
+            .leptos_routes(
+                leptos_options.clone(),
+                routes,
+                move |cx| view! { cx, <Home flow=flow.clone() /> },
+            )
+            .layer(Extension(Arc::new(leptos_options)));
 
         let (Ok(()) | Err(_)) = tokio::io::stderr()
             .write_all(format!("listening on http://{}\n", socket_addr).as_bytes())
+            .await;
+        let (Ok(()) | Err(_)) = tokio::io::stderr()
+            .write_all(
+                format!(
+                    "working dir: {}\n",
+                    std::env::current_dir().unwrap().display()
+                )
+                .as_bytes(),
+            )
             .await;
         axum::Server::bind(&socket_addr)
             .serve(app.into_make_service())
             .await
             .map_err(|error| EnvManError::WebServerServe { error })
     }
-}
-
-/// Renders the home page directly from the request
-///
-/// The `Home` page includes the glue code to connect to the WebSocket on the
-/// `"/ws"` route.
-async fn root(socket_addr: SocketAddr) -> Html<String> {
-    // The root page blocks on futures so we need to render it in a spawn_blocking
-    // task
-    tokio::task::spawn_blocking(move || async move {
-        let mut app = VirtualDom::new_with_props(Home, HomeProps { socket_addr });
-        let _ = app.rebuild();
-        Html(format!(
-            r#"
-            <!DOCTYPE html>
-            <html>
-                {home}
-            </html>
-            "#,
-            home = dioxus_ssr::render(&app)
-        ))
-    })
-    .await
-    .map_err(|error| EnvManError::WebServerRenderJoin { error })
-    .expect("Expected web server render thread to join successfully.")
-    .await
 }

--- a/examples/envman/src/web/web_server.rs
+++ b/examples/envman/src/web/web_server.rs
@@ -1,10 +1,15 @@
 use std::net::{IpAddr, SocketAddr};
 
-use axum::{response::Html, routing::get, Router};
+use axum::{extract::WebSocketUpgrade, response::Html, routing::get, Router};
 use dioxus::prelude::VirtualDom;
+use tokio::io::AsyncWriteExt;
 use tower_http::services::ServeDir;
 
-use crate::{model::EnvManError, web::components::Home};
+use crate::{
+    flows::AppUploadFlow,
+    model::EnvManError,
+    web::components::{FlowGraph, FlowGraphProps, Home, HomeProps},
+};
 
 /// Web server that responds to `envman` requests.
 #[derive(Debug)]
@@ -16,33 +21,67 @@ pub struct WebServer {}
 impl WebServer {
     /// Starts the web server.
     pub async fn start(ip_addr: IpAddr, port: u16) -> Result<(), EnvManError> {
-        let addr = SocketAddr::from((ip_addr, port));
+        let socket_addr = SocketAddr::from((ip_addr, port));
+
+        let view = dioxus_liveview::LiveViewPool::new();
 
         let app = Router::new()
             // serve the public directory
             .nest_service("/public", ServeDir::new("public"))
             // serve the SSR rendered homepage
-            .route("/", get(root));
+            .route("/", get(move || root(socket_addr)))
+            // The WebSocket route is what Dioxus uses to communicate with the browser
+            .route(
+                "/ws",
+                get(move |ws: WebSocketUpgrade| async move {
+                    ws.on_upgrade(move |socket| async move {
+                        let flow = AppUploadFlow::flow().await.unwrap();
 
-        println!("listening on http://{}", addr);
-        println!("- Route available on http://{}", addr);
-        axum::Server::bind(&addr)
+                        // When the WebSocket is upgraded, launch the LiveView with the app
+                        // component
+                        _ = view
+                            .launch_with_props(
+                                dioxus_liveview::axum_socket(socket),
+                                FlowGraph,
+                                FlowGraphProps { flow },
+                            )
+                            .await;
+                    })
+                }),
+            );
+
+        let (Ok(()) | Err(_)) = tokio::io::stderr()
+            .write_all(format!("listening on http://{}", socket_addr).as_bytes())
+            .await;
+        axum::Server::bind(&socket_addr)
             .serve(app.into_make_service())
             .await
             .map_err(|error| EnvManError::WebServerServe { error })
     }
 }
 
-// Just render a simple page directly from the request
-async fn root() -> Html<String> {
+/// Renders the home page directly from the request
+///
+/// The `Home` page includes the glue code to connect to the WebSocket on the
+/// `"/ws"` route.
+async fn root(socket_addr: SocketAddr) -> Html<String> {
     // The root page blocks on futures so we need to render it in a spawn_blocking
     // task
     tokio::task::spawn_blocking(move || async move {
-        let mut app = VirtualDom::new(Home);
+        let mut app = VirtualDom::new_with_props(Home, HomeProps { socket_addr });
         let _ = app.rebuild();
-        Html(dioxus_ssr::render(&app))
+        Html(format!(
+            r#"
+            <!DOCTYPE html>
+            <html>
+                {home}
+            </html>
+            "#,
+            home = dioxus_ssr::render(&app)
+        ))
     })
     .await
-    .unwrap()
+    .map_err(|error| EnvManError::WebServerRenderJoin { error })
+    .expect("Expected web server render thread to join successfully.")
     .await
 }

--- a/items/sh_cmd/src/sh_cmd_apply_fns.rs
+++ b/items/sh_cmd/src/sh_cmd_apply_fns.rs
@@ -42,7 +42,7 @@ where
         ShCmdExecutor::<Id>::exec(&apply_check_sh_cmd)
             .await
             .and_then(|state| match state.logical {
-                ShCmdState::Some { stdout, .. } => match stdout.trim().lines().rev().next() {
+                ShCmdState::Some { stdout, .. } => match stdout.trim().lines().next_back() {
                     Some("true") => {
                         #[cfg(not(feature = "output_progress"))]
                         {

--- a/items/sh_cmd/src/sh_cmd_executor.rs
+++ b/items/sh_cmd/src/sh_cmd_executor.rs
@@ -42,7 +42,7 @@ impl<Id> ShCmdExecutor<Id> {
             let invalid_span = {
                 let start = error.valid_up_to();
                 let len = error.error_len().unwrap_or(1);
-                miette::SourceSpan::from((start, len))
+                peace::miette::SourceSpan::from((start, len))
             };
 
             ShCmdError::StdoutNonUtf8 {
@@ -62,7 +62,7 @@ impl<Id> ShCmdExecutor<Id> {
                 let invalid_span = {
                     let start = error.valid_up_to();
                     let len = error.error_len().unwrap_or(1);
-                    miette::SourceSpan::from((start, len))
+                    peace::miette::SourceSpan::from((start, len))
                 };
 
                 ShCmdError::StderrNonUtf8 {

--- a/items/tar_x/src/tar_x_apply_fns.rs
+++ b/items/tar_x/src/tar_x_apply_fns.rs
@@ -140,7 +140,7 @@ where
     #[cfg(target_arch = "wasm32")]
     pub async fn apply(
         _fn_ctx: FnCtx<'_>,
-        params: &TarXParams<Id>,
+        _params: &TarXParams<Id>,
         _data: TarXData<'_, Id>,
         _state_current: &FileMetadatas,
         _state_desired: &FileMetadatas,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,15 @@ pub use peace_resources as resources;
 pub use peace_rt as rt;
 pub use peace_rt_model as rt_model;
 
+// We still can't build with `--all-features`, even with `indicatif 0.17.4`.
+//
+// The error we get is the same as in
+// <https://github.com/rustwasm/wasm-bindgen/issues/2160>.
+//
+// This likely means at least one of the transitive dependencies of `indicatif`
+// uses `std::env::*`.
+//
+// `console` is at lesat one of these dependencies.
 #[cfg(all(target_arch = "wasm32", feature = "output_progress"))]
 compile_error!(
     r#"The `"output_progress"` feature does not work on WASM, pending support from `indicatif`.

--- a/workspace_tests/Cargo.toml
+++ b/workspace_tests/Cargo.toml
@@ -23,7 +23,8 @@ diff-struct = "0.5.1"
 derivative = { workspace = true }
 futures = "0.3.28"
 peace = { path = "..", version = "0.0.9", default-features = false }
-peace_items = { path = "../items", version = "0.0.9" }
+# `ItemWrapper` always needs the `blank` item spec to be present.
+peace_items = { path = "../items", version = "0.0.9", features = ["blank"] }
 pretty_assertions = "1.3.0"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
@@ -460,7 +460,7 @@ async fn build_with_item_params_returns_err_when_params_not_provided_and_not_sto
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsMismatch {
                     item_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
@@ -616,7 +616,7 @@ async fn build_with_item_params_returns_err_when_params_provided_mismatch()
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsMismatch {
                     item_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
@@ -685,7 +685,7 @@ async fn build_with_item_params_returns_err_when_params_stored_mismatch()
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsMismatch {
                     item_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
@@ -830,7 +830,7 @@ async fn build_with_item_params_returns_err_when_spec_fully_not_provided_for_pre
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsMismatch {
                     item_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
@@ -900,7 +900,7 @@ async fn build_with_item_params_returns_err_when_value_spec_not_provided_for_pre
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsMismatch {
                     item_ids_with_no_params_specs,
                     params_specs_provided_mismatches,
@@ -962,7 +962,7 @@ async fn build_with_item_params_returns_deserialization_err_when_item_renamed()
     assert!(
         matches!(
             &cmd_ctx_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ParamsSpecsDeserialize {
                     profile,
                     flow_id,

--- a/workspace_tests/src/peace_test_error.rs
+++ b/workspace_tests/src/peace_test_error.rs
@@ -17,6 +17,15 @@ pub enum PeaceTestError {
         crate::VecCopyError,
     ),
 
+    /// A Blank item error occurred.
+    #[error("A Blank item error occurred.")]
+    BlankError(
+        #[cfg_attr(feature = "error_reporting", diagnostic_source)]
+        #[source]
+        #[from]
+        peace_items::blank::BlankError,
+    ),
+
     /// A `peace` runtime error occurred.
     #[error("A `peace` runtime error occurred.")]
     PeaceRtError(

--- a/workspace_tests/src/peace_test_error.rs
+++ b/workspace_tests/src/peace_test_error.rs
@@ -10,7 +10,7 @@ use peace::miette;
 pub enum PeaceTestError {
     /// A VecCopy item error occurred.
     #[error("A VecCopy item error occurred.")]
-    VecCopyError(
+    VecCopy(
         #[cfg_attr(feature = "error_reporting", diagnostic_source)]
         #[source]
         #[from]
@@ -19,7 +19,7 @@ pub enum PeaceTestError {
 
     /// A Blank item error occurred.
     #[error("A Blank item error occurred.")]
-    BlankError(
+    Blank(
         #[cfg_attr(feature = "error_reporting", diagnostic_source)]
         #[source]
         #[from]
@@ -28,7 +28,7 @@ pub enum PeaceTestError {
 
     /// A `peace` runtime error occurred.
     #[error("A `peace` runtime error occurred.")]
-    PeaceRtError(
+    PeaceRt(
         #[cfg_attr(feature = "error_reporting", diagnostic_source)]
         #[source]
         #[from]

--- a/workspace_tests/src/rt/cmds/diff_cmd.rs
+++ b/workspace_tests/src/rt/cmds/diff_cmd.rs
@@ -185,7 +185,7 @@ async fn diff_profiles_current_with_missing_profile_0() -> Result<(), Box<dyn st
 
     assert!(matches!(
             diff_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ProfileNotInScope { profile, profiles_in_scope }
             ))
             if profile == profile_0 && profiles_in_scope == vec![profile_1]));
@@ -232,7 +232,7 @@ async fn diff_profiles_current_with_missing_profile_1() -> Result<(), Box<dyn st
 
     assert!(matches!(
             diff_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ProfileNotInScope { profile, profiles_in_scope }
             ))
             if profile == profile_1 && profiles_in_scope == vec![profile_0]));
@@ -291,7 +291,7 @@ async fn diff_profiles_current_with_profile_0_missing_states_current()
 
     assert!(matches!(
             diff_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ProfileStatesCurrentNotDiscovered { profile }
             ))
             if profile == profile_0));
@@ -348,7 +348,7 @@ async fn diff_profiles_current_with_profile_1_missing_states_current()
 
     assert!(matches!(
             diff_result,
-            Err(PeaceTestError::PeaceRtError(
+            Err(PeaceTestError::PeaceRt(
                 peace::rt_model::Error::ProfileStatesCurrentNotDiscovered { profile }
             ))
             if profile == profile_1));

--- a/workspace_tests/src/rt/cmds/states_desired_display_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_desired_display_cmd.rs
@@ -98,11 +98,11 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
 
     assert!(matches!(
         exec_result,
-        Err(PeaceTestError::PeaceRtError(
+        Err(PeaceTestError::PeaceRt(
             Error::StatesDesiredDiscoverRequired
         ))
     ));
-    let err = PeaceTestError::PeaceRtError(Error::StatesDesiredDiscoverRequired);
+    let err = PeaceTestError::PeaceRt(Error::StatesDesiredDiscoverRequired);
     assert_eq!(
         vec![FnInvocation::new(
             "write_err",

--- a/workspace_tests/src/rt/cmds/states_saved_display_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_saved_display_cmd.rs
@@ -98,11 +98,11 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
 
     assert!(matches!(
         exec_result,
-        Err(PeaceTestError::PeaceRtError(
+        Err(PeaceTestError::PeaceRt(
             Error::StatesCurrentDiscoverRequired
         ))
     ));
-    let err = PeaceTestError::PeaceRtError(Error::StatesCurrentDiscoverRequired);
+    let err = PeaceTestError::PeaceRt(Error::StatesCurrentDiscoverRequired);
     assert_eq!(
         vec![FnInvocation::new(
             "write_err",

--- a/workspace_tests/src/rt/cmds/sub/states_desired_read_cmd.rs
+++ b/workspace_tests/src/rt/cmds/sub/states_desired_read_cmd.rs
@@ -84,7 +84,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
 
     assert!(matches!(
         exec_result,
-        Err(PeaceTestError::PeaceRtError(
+        Err(PeaceTestError::PeaceRt(
             Error::StatesDesiredDiscoverRequired
         ))
     ));

--- a/workspace_tests/src/rt/cmds/sub/states_saved_read_cmd.rs
+++ b/workspace_tests/src/rt/cmds/sub/states_saved_read_cmd.rs
@@ -84,7 +84,7 @@ async fn returns_error_when_states_not_on_disk() -> Result<(), Box<dyn std::erro
 
     assert!(matches!(
         exec_result,
-        Err(PeaceTestError::PeaceRtError(
+        Err(PeaceTestError::PeaceRt(
             Error::StatesCurrentDiscoverRequired
         ))
     ));


### PR DESCRIPTION
Closes #125.

* Generate GraphViz dot diagram from `Flow`.
* Use [tailwindcss](https://tailwindcss.com/) to style GraphViz diagram.
* Add instructions for web development workflow.

If we use `dioxus`, then the cargo audit and licenses checks are pending a release (to pick up https://github.com/DioxusLabs/dioxus/pull/1049), or we could use `leptos`.
