### PR TITLE
Guard `ApplyCmd::exec` if stored states out of sync with discovered states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Rename `StatesDesired*` to `StatesGoal*`. ([#131], [#132])
 * Add `StatesGoalStored` to distinguish between stored and discovered `StatesGoal`. ([#131], [#132])
 * `DiffCmd::diff{,_with}` supports discovery of state during diffing. ([#133], [#134])
+* Add `PartialEq` bound to `Item::State`. ([#59], [#135])
+* Guard `EnsureCmd::{exec,exec_dry}` if stored current state or goal state is not in sync with actual. ([#59], [#135])
+* Guard `CleanCmd::{exec,exec_dry}` if stored current state is not in sync with actual. ([#59], [#135])
 
 [#120]: https://github.com/azriel91/peace/issues/120
 [#130]: https://github.com/azriel91/peace/pull/130
@@ -13,6 +16,8 @@
 [#132]: https://github.com/azriel91/peace/pull/132
 [#133]: https://github.com/azriel91/peace/issues/133
 [#134]: https://github.com/azriel91/peace/pull/134
+[#59]: https://github.com/azriel91/peace/issues/59
+[#135]: https://github.com/azriel91/peace/pull/135
 
 
 ## 0.0.10 (2023-06-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `PartialEq` bound to `Item::State`. ([#59], [#135])
 * Guard `EnsureCmd::{exec,exec_dry}` if stored current state or goal state is not in sync with actual. ([#59], [#135])
 * Guard `CleanCmd::{exec,exec_dry}` if stored current state is not in sync with actual. ([#59], [#135])
+* Add `*Cmd::*_with` for command logic to be executed as sub commands. ([#59], [#135])
 
 [#120]: https://github.com/azriel91/peace/issues/120
 [#130]: https://github.com/azriel91/peace/pull/130

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ thiserror = "1.0.40"
 tokio = "1.28.2"
 tokio-util = "0.7.8"
 tynm = "0.1.8"
-type_reg = { version = "0.5.1", features = ["debug", "untagged", "ordered"] }
+type_reg = { version = "0.5.2", features = ["debug", "untagged", "ordered"] }
 url = "2.3.1"
 wasm-bindgen = "0.2.86"
 web-sys = "0.3.63"

--- a/crate/cfg/src/item.rs
+++ b/crate/cfg/src/item.rs
@@ -77,7 +77,15 @@ pub trait Item: DynClone {
     ///
     /// [state concept]: https://peace.mk/book/technical_concepts/state.html
     /// [`State`]: crate::state::State
-    type State: Clone + Debug + Display + Serialize + DeserializeOwned + Send + Sync + 'static;
+    type State: Clone
+        + Debug
+        + Display
+        + PartialEq
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + 'static;
 
     /// Diff between the current and target [`State`]s.
     ///

--- a/crate/cmd/Cargo.toml
+++ b/crate/cmd/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 test = false
 
 [dependencies]
+cfg-if = { workspace = true }
 futures = { workspace = true }
 indicatif = { workspace = true, optional = true, features = ["tokio"] }
 peace_cfg = { workspace = true }

--- a/crate/cmd/src/cmd_independence.rs
+++ b/crate/cmd/src/cmd_independence.rs
@@ -1,0 +1,60 @@
+//! Information about how command logic should be run.
+//!
+//! This is information used when implementing commands, not necessarily
+//! information that developers who *use* commands need to know.
+//!
+//! If we need to pass multiple kinds of information of how command logic should
+//! be run, we should group them together as a `CmdCtxInternal` or similar.
+
+use peace_resources::resources::ts::SetUp;
+use peace_rt_model::params::ParamsKeys;
+
+use crate::{
+    ctx::CmdCtx,
+    scopes::{SingleProfileSingleFlow, SingleProfileSingleFlowView},
+};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "output_progress")] {
+        use peace_cfg::progress::ProgressUpdateAndId;
+        use tokio::sync::mpsc::Sender;
+    }
+}
+
+/// Whether a command is an independent top level command, or as part of another
+/// command.
+///
+/// # Design
+///
+/// The three lifetimes are present because of the complexity of the
+/// [`CmdBase::exec`] function. See the documentation on that function for the
+/// technical necessity and rationale for choosing separate lifetimes here.
+///
+/// [`CmdBase::exec`]: crate::cmds::CmdBase::exec
+#[derive(Debug)]
+pub enum CmdIndependence<'ctx, 'scope, 'view, E, O, PKeys>
+where
+    E: 'static,
+    PKeys: ParamsKeys + 'static,
+{
+    /// This command is being executed as a top level command.
+    Standalone {
+        cmd_ctx: &'ctx mut CmdCtx<SingleProfileSingleFlow<'scope, E, O, PKeys, SetUp>>,
+    },
+    /// This command is being executed as part of another command.
+    ///
+    /// This takes only the view; sub commands will not have access to the
+    /// `output`, which is held by the top level standalone command.
+    SubCmd {
+        /// Flow and parameters for executing the command.
+        cmd_view: &'ctx mut SingleProfileSingleFlowView<'view, E, PKeys, SetUp>,
+    },
+    /// This command is being executed as part of another command.
+    #[cfg(feature = "output_progress")]
+    SubCmdWithProgress {
+        /// Flow and parameters for executing the command.
+        cmd_view: &'ctx mut SingleProfileSingleFlowView<'view, E, PKeys, SetUp>,
+        /// Sender to use for progress updates.
+        progress_tx: Sender<ProgressUpdateAndId>,
+    },
+}

--- a/crate/cmd/src/cmd_independence.rs
+++ b/crate/cmd/src/cmd_independence.rs
@@ -24,6 +24,18 @@ cfg_if::cfg_if! {
 /// Whether a command is an independent top level command, or as part of another
 /// command.
 ///
+/// # Examples
+///
+/// Instead of constructing one of these variants directly, there are
+/// convenience functions on the [`CmdCtx`] and [`SingleProfileSingleFlowView`]
+/// types when using one of the `*Cmd::*_with(..)` functions.
+///
+/// ```rust,ignore
+/// &mut cmd_ctx.as_standalone();
+/// &mut cmd_ctx.view().as_sub_cmd();
+/// &mut cmd_ctx.view().as_sub_cmd_with_progress(progress_tx.clone());
+/// ```
+///
 /// # Design
 ///
 /// The three lifetimes are present because of the complexity of the

--- a/crate/cmd/src/lib.rs
+++ b/crate/cmd/src/lib.rs
@@ -1,4 +1,8 @@
 //! Command structure for the Peace framework.
 
+pub use crate::cmd_independence::CmdIndependence;
+
 pub mod ctx;
 pub mod scopes;
+
+mod cmd_independence;

--- a/crate/rt/src/cmds.rs
+++ b/crate/rt/src/cmds.rs
@@ -21,7 +21,6 @@ pub use self::{
     sub::ApplyStoredStateSync,
 };
 
-pub mod cmd_ctx_internal;
 pub mod sub;
 
 mod clean_cmd;

--- a/crate/rt/src/cmds.rs
+++ b/crate/rt/src/cmds.rs
@@ -18,6 +18,7 @@ pub use self::{
     states_discover_cmd::StatesDiscoverCmd,
     states_goal_display_cmd::StatesGoalDisplayCmd,
     states_goal_read_cmd::StatesGoalReadCmd,
+    sub::ApplyStoredStateSync,
 };
 
 pub mod cmd_ctx_internal;

--- a/crate/rt/src/cmds/clean_cmd.rs
+++ b/crate/rt/src/cmds/clean_cmd.rs
@@ -5,7 +5,7 @@ use peace_resources::{
     resources::ts::SetUp,
     states::{
         ts::{Cleaned, CleanedDry},
-        StatesCleaned, StatesCleanedDry, StatesCurrentStored,
+        StatesCleaned, StatesCleanedDry,
     },
 };
 use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error};
@@ -58,14 +58,8 @@ where
     /// [`Item`]: peace_cfg::Item
     pub async fn exec_dry(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesCleanedDry, E>, E> {
-        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_dry(
-            cmd_ctx,
-            states_current_stored,
-            ApplyFor::Clean,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_dry(cmd_ctx, ApplyFor::Clean).await
     }
 
     /// Runs [`Item::apply_exec_dry`] for each [`Item`], with [`state_clean`] as
@@ -80,11 +74,9 @@ where
     /// [`state_clean`]: peace_cfg::Item::state_clean
     pub async fn exec_dry_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesCleanedDry, E>, E> {
         ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_dry_with(
             cmd_independence,
-            states_current_stored,
             ApplyFor::Clean,
         )
         .await
@@ -124,14 +116,8 @@ where
     /// [`Item`]: peace_cfg::Item
     pub async fn exec(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesCleaned, E>, E> {
-        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec(
-            cmd_ctx,
-            states_current_stored,
-            ApplyFor::Clean,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec(cmd_ctx, ApplyFor::Clean).await
     }
 
     /// Runs [`Item::apply_exec`] for each [`Item`], with [`state_clean`] as the
@@ -146,14 +132,9 @@ where
     /// [`state_clean`]: peace_cfg::Item::state_clean
     pub async fn exec_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesCleaned, E>, E> {
-        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_with(
-            cmd_independence,
-            states_current_stored,
-            ApplyFor::Clean,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_with(cmd_independence, ApplyFor::Clean)
+            .await
     }
 }
 

--- a/crate/rt/src/cmds/clean_cmd.rs
+++ b/crate/rt/src/cmds/clean_cmd.rs
@@ -13,6 +13,7 @@ use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKe
 use crate::cmds::{
     cmd_ctx_internal::CmdIndependence,
     sub::{ApplyCmd, ApplyFor},
+    ApplyStoredStateSync,
 };
 
 #[derive(Debug)]
@@ -74,10 +75,12 @@ where
     /// [`state_clean`]: peace_cfg::Item::state_clean
     pub async fn exec_dry_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        apply_stored_state_sync: ApplyStoredStateSync,
     ) -> Result<CmdOutcome<StatesCleanedDry, E>, E> {
         ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_dry_with(
             cmd_independence,
             ApplyFor::Clean,
+            apply_stored_state_sync,
         )
         .await
     }
@@ -132,9 +135,14 @@ where
     /// [`state_clean`]: peace_cfg::Item::state_clean
     pub async fn exec_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        apply_stored_state_sync: ApplyStoredStateSync,
     ) -> Result<CmdOutcome<StatesCleaned, E>, E> {
-        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_with(cmd_independence, ApplyFor::Clean)
-            .await
+        ApplyCmd::<E, O, PKeys, Cleaned, CleanedDry>::exec_with(
+            cmd_independence,
+            ApplyFor::Clean,
+            apply_stored_state_sync,
+        )
+        .await
     }
 }
 

--- a/crate/rt/src/cmds/clean_cmd.rs
+++ b/crate/rt/src/cmds/clean_cmd.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use peace_cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow};
+use peace_cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow, CmdIndependence};
 use peace_resources::{
     resources::ts::SetUp,
     states::{
@@ -11,7 +11,6 @@ use peace_resources::{
 use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error};
 
 use crate::cmds::{
-    cmd_ctx_internal::CmdIndependence,
     sub::{ApplyCmd, ApplyFor},
     ApplyStoredStateSync,
 };

--- a/crate/rt/src/cmds/cmd_base.rs
+++ b/crate/rt/src/cmds/cmd_base.rs
@@ -2,14 +2,12 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use futures::future::LocalBoxFuture;
 use peace_cfg::ItemId;
-use peace_cmd::scopes::SingleProfileSingleFlowView;
+use peace_cmd::{scopes::SingleProfileSingleFlowView, CmdIndependence};
 use peace_resources::resources::ts::SetUp;
 use peace_rt_model::{
     outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error, IndexMap,
 };
 use tokio::sync::{mpsc, mpsc::UnboundedSender};
-
-use crate::cmds::cmd_ctx_internal::CmdIndependence;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {

--- a/crate/rt/src/cmds/diff_cmd.rs
+++ b/crate/rt/src/cmds/diff_cmd.rs
@@ -183,7 +183,7 @@ where
                             };
 
                             let states_current_outcome =
-                                StatesDiscoverCmd::current_with(&mut cmd_independence).await;
+                                StatesDiscoverCmd::current_with(&mut cmd_independence, true).await;
                             match states_current_outcome {
                                 Ok(states_current_outcome) => {
                                     outcomes_tx
@@ -261,7 +261,7 @@ where
                             };
 
                             let states_goal_outcome =
-                                StatesDiscoverCmd::goal_with(&mut cmd_independence).await;
+                                StatesDiscoverCmd::goal_with(&mut cmd_independence, true).await;
                             match states_goal_outcome {
                                 Ok(states_goal_outcome) => {
                                     outcomes_tx

--- a/crate/rt/src/cmds/diff_cmd.rs
+++ b/crate/rt/src/cmds/diff_cmd.rs
@@ -8,6 +8,7 @@ use peace_cmd::{
         MultiProfileSingleFlow, MultiProfileSingleFlowView, SingleProfileSingleFlow,
         SingleProfileSingleFlowView,
     },
+    CmdIndependence,
 };
 use peace_params::ParamsSpecs;
 use peace_resources::{
@@ -21,10 +22,7 @@ use peace_resources::{
 };
 use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error, Flow};
 
-use crate::cmds::{
-    cmd_ctx_internal::CmdIndependence, CmdBase, StatesCurrentReadCmd, StatesDiscoverCmd,
-    StatesGoalReadCmd,
-};
+use crate::cmds::{CmdBase, StatesCurrentReadCmd, StatesDiscoverCmd, StatesGoalReadCmd};
 
 pub use self::{diff_info_spec::DiffInfoSpec, diff_state_spec::DiffStateSpec};
 

--- a/crate/rt/src/cmds/diff_cmd.rs
+++ b/crate/rt/src/cmds/diff_cmd.rs
@@ -56,7 +56,7 @@ where
     pub async fn diff_stored(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<StateDiffs, E> {
-        Self::diff_stored_with(&mut CmdIndependence::Standalone { cmd_ctx }).await
+        Self::diff_stored_with(&mut cmd_ctx.as_standalone()).await
     }
 
     /// Returns the [`state_diff`]`s between the stored current and goal
@@ -91,7 +91,7 @@ where
         diff_state_spec_b: DiffStateSpec,
     ) -> Result<CmdOutcome<StateDiffs, E>, E> {
         Self::diff_with(
-            &mut CmdIndependence::Standalone { cmd_ctx },
+            &mut cmd_ctx.as_standalone(),
             diff_state_spec_a,
             diff_state_spec_b,
         )

--- a/crate/rt/src/cmds/ensure_cmd.rs
+++ b/crate/rt/src/cmds/ensure_cmd.rs
@@ -13,6 +13,7 @@ use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKe
 use crate::cmds::{
     cmd_ctx_internal::CmdIndependence,
     sub::{ApplyCmd, ApplyFor},
+    ApplyStoredStateSync,
 };
 
 #[derive(Debug)]
@@ -66,10 +67,12 @@ where
     /// [`state_goal`]: peace_cfg::Item::state_goal
     pub async fn exec_dry_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        apply_stored_state_sync: ApplyStoredStateSync,
     ) -> Result<CmdOutcome<StatesEnsuredDry, E>, E> {
         ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_dry_with(
             cmd_independence,
             ApplyFor::Ensure,
+            apply_stored_state_sync,
         )
         .await
     }
@@ -116,9 +119,14 @@ where
     /// [`state_goal`]: peace_cfg::Item::state_goal
     pub async fn exec_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        apply_stored_state_sync: ApplyStoredStateSync,
     ) -> Result<CmdOutcome<StatesEnsured, E>, E> {
-        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_with(cmd_independence, ApplyFor::Ensure)
-            .await
+        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_with(
+            cmd_independence,
+            ApplyFor::Ensure,
+            apply_stored_state_sync,
+        )
+        .await
     }
 }
 

--- a/crate/rt/src/cmds/ensure_cmd.rs
+++ b/crate/rt/src/cmds/ensure_cmd.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData};
 
-use peace_cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow};
+use peace_cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow, CmdIndependence};
 use peace_resources::{
     resources::ts::SetUp,
     states::{
@@ -11,7 +11,6 @@ use peace_resources::{
 use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error};
 
 use crate::cmds::{
-    cmd_ctx_internal::CmdIndependence,
     sub::{ApplyCmd, ApplyFor},
     ApplyStoredStateSync,
 };

--- a/crate/rt/src/cmds/ensure_cmd.rs
+++ b/crate/rt/src/cmds/ensure_cmd.rs
@@ -5,7 +5,7 @@ use peace_resources::{
     resources::ts::SetUp,
     states::{
         ts::{Ensured, EnsuredDry},
-        StatesCurrentStored, StatesEnsured, StatesEnsuredDry,
+        StatesEnsured, StatesEnsuredDry,
     },
 };
 use peace_rt_model::{outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error};
@@ -50,14 +50,8 @@ where
     /// [`Item`]: peace_cfg::Item
     pub async fn exec_dry(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesEnsuredDry, E>, E> {
-        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_dry(
-            cmd_ctx,
-            states_current_stored,
-            ApplyFor::Ensure,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_dry(cmd_ctx, ApplyFor::Ensure).await
     }
 
     /// Runs [`Item::apply_exec_dry`] for each [`Item`], with [`state_goal`]
@@ -72,11 +66,9 @@ where
     /// [`state_goal`]: peace_cfg::Item::state_goal
     pub async fn exec_dry_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesEnsuredDry, E>, E> {
         ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_dry_with(
             cmd_independence,
-            states_current_stored,
             ApplyFor::Ensure,
         )
         .await
@@ -108,14 +100,8 @@ where
     /// [`Item`]: peace_cfg::Item
     pub async fn exec(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesEnsured, E>, E> {
-        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec(
-            cmd_ctx,
-            states_current_stored,
-            ApplyFor::Ensure,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec(cmd_ctx, ApplyFor::Ensure).await
     }
 
     /// Runs [`Item::apply_exec`] for each [`Item`], with [`state_goal`] as
@@ -130,14 +116,9 @@ where
     /// [`state_goal`]: peace_cfg::Item::state_goal
     pub async fn exec_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
-        states_current_stored: &StatesCurrentStored,
     ) -> Result<CmdOutcome<StatesEnsured, E>, E> {
-        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_with(
-            cmd_independence,
-            states_current_stored,
-            ApplyFor::Ensure,
-        )
-        .await
+        ApplyCmd::<E, O, PKeys, Ensured, EnsuredDry>::exec_with(cmd_independence, ApplyFor::Ensure)
+            .await
     }
 }
 

--- a/crate/rt/src/cmds/states_current_read_cmd.rs
+++ b/crate/rt/src/cmds/states_current_read_cmd.rs
@@ -5,6 +5,7 @@ use peace_cfg::{FlowId, ItemId};
 use peace_cmd::{
     ctx::CmdCtx,
     scopes::{SingleProfileSingleFlow, SingleProfileSingleFlowView},
+    CmdIndependence,
 };
 use peace_resources::{
     paths::{FlowDir, StatesCurrentFile},
@@ -16,7 +17,7 @@ use peace_resources::{
 use peace_rt_model::{params::ParamsKeys, Error, StatesSerializer, Storage};
 use peace_rt_model_core::output::OutputWrite;
 
-use crate::cmds::{cmd_ctx_internal::CmdIndependence, CmdBase};
+use crate::cmds::CmdBase;
 
 /// Reads [`StatesCurrentStored`]s from storage.
 #[derive(Debug)]

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -61,6 +61,8 @@ where
     /// inserted it into `Resources`, and the successor should references it
     /// in their [`Data`].
     ///
+    /// This function will always serialize states to storage.
+    ///
     /// [`Current<T>`]: https://docs.rs/peace_data/latest/peace_data/marker/struct.Current.html
     /// [`Data`]: peace_cfg::TryFnSpec::Data
     /// [`Item`]: peace_cfg::Item
@@ -68,7 +70,7 @@ where
     pub async fn current(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<CmdOutcome<StatesCurrent, E>, E> {
-        Self::current_with(&mut CmdIndependence::Standalone { cmd_ctx }).await
+        Self::current_with(&mut CmdIndependence::Standalone { cmd_ctx }, true).await
     }
 
     /// Runs [`try_state_current`] for each [`Item`].
@@ -78,11 +80,19 @@ where
     /// This function exists so that this command can be executed as sub
     /// functionality of another command.
     ///
+    /// # Parameters
+    ///
+    /// * `cmd_independence`: Whether this command is run as a top level
+    ///   command, or part of a subcommand.
+    /// * `serialize_to_storage`: Whether to write states to storage after
+    ///   discovery.
+    ///
     /// [`try_state_current`]: peace_cfg::Item::try_state_current
     pub async fn current_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        serialize_to_storage: bool,
     ) -> Result<CmdOutcome<StatesCurrent, E>, E> {
-        Self::exec(cmd_independence, DiscoverFor::Current)
+        Self::exec(cmd_independence, DiscoverFor::Current, serialize_to_storage)
             .await
             .map(|cmd_outcome| {
                 let CmdOutcome {
@@ -109,6 +119,8 @@ where
     /// inserted it into `Resources`, and the successor should references it
     /// in their [`Data`].
     ///
+    /// This function will always serialize states to storage.
+    ///
     /// [`Data`]: peace_cfg::TryFnSpec::Data
     /// [`Goal<T>`]: https://docs.rs/peace_data/latest/peace_data/marker/struct.Goal.html
     /// [`Item`]: peace_cfg::Item
@@ -116,7 +128,7 @@ where
     pub async fn goal(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<CmdOutcome<StatesGoal, E>, E> {
-        Self::goal_with(&mut CmdIndependence::Standalone { cmd_ctx }).await
+        Self::goal_with(&mut CmdIndependence::Standalone { cmd_ctx }, true).await
     }
 
     /// Runs [`try_state_goal`] for each [`Item`].
@@ -129,8 +141,9 @@ where
     /// [`try_state_goal`]: peace_cfg::Item::try_state_goal
     pub async fn goal_with(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
+        serialize_to_storage: bool,
     ) -> Result<CmdOutcome<StatesGoal, E>, E> {
-        Self::exec(cmd_independence, DiscoverFor::Goal)
+        Self::exec(cmd_independence, DiscoverFor::Goal, serialize_to_storage)
             .await
             .map(|cmd_outcome| {
                 let CmdOutcome {
@@ -164,6 +177,8 @@ where
     /// automatically inserted it into `Resources`, and the successor should
     /// references it in their [`Data`].
     ///
+    /// This function will always serialize states to storage.
+    ///
     /// [`Current<T>`]: https://docs.rs/peace_data/latest/peace_data/marker/struct.Current.html
     /// [`Data`]: peace_cfg::TryFnSpec::Data
     /// [`Goal<T>`]: https://docs.rs/peace_data/latest/peace_data/marker/struct.Goal.html
@@ -176,6 +191,7 @@ where
         Self::exec(
             &mut CmdIndependence::Standalone { cmd_ctx },
             DiscoverFor::CurrentAndGoal,
+            true,
         )
         .await
     }
@@ -185,6 +201,7 @@ where
     async fn exec(
         cmd_independence: &mut CmdIndependence<'_, '_, '_, E, O, PKeys>,
         discover_for: DiscoverFor,
+        serialize_to_storage: bool,
     ) -> Result<CmdOutcome<(StatesCurrent, StatesGoal), E>, E> {
         let outcome = {
             let states_current_mut = StatesMut::<Current>::new();
@@ -400,16 +417,18 @@ where
             CmdIndependence::SubCmdWithProgress { cmd_view, .. } => cmd_view.resources,
         };
 
-        match discover_for {
-            DiscoverFor::Current => {
-                Self::serialize_current(resources, states_current).await?;
-            }
-            DiscoverFor::Goal => {
-                Self::serialize_goal(resources, states_goal).await?;
-            }
-            DiscoverFor::CurrentAndGoal => {
-                Self::serialize_current(resources, states_current).await?;
-                Self::serialize_goal(resources, states_goal).await?;
+        if serialize_to_storage {
+            match discover_for {
+                DiscoverFor::Current => {
+                    Self::serialize_current(resources, states_current).await?;
+                }
+                DiscoverFor::Goal => {
+                    Self::serialize_goal(resources, states_goal).await?;
+                }
+                DiscoverFor::CurrentAndGoal => {
+                    Self::serialize_current(resources, states_current).await?;
+                    Self::serialize_goal(resources, states_goal).await?;
+                }
             }
         }
 

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -70,7 +70,7 @@ where
     pub async fn current(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<CmdOutcome<StatesCurrent, E>, E> {
-        Self::current_with(&mut CmdIndependence::Standalone { cmd_ctx }, true).await
+        Self::current_with(&mut cmd_ctx.as_standalone(), true).await
     }
 
     /// Runs [`try_state_current`] for each [`Item`].
@@ -128,7 +128,7 @@ where
     pub async fn goal(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<CmdOutcome<StatesGoal, E>, E> {
-        Self::goal_with(&mut CmdIndependence::Standalone { cmd_ctx }, true).await
+        Self::goal_with(&mut cmd_ctx.as_standalone(), true).await
     }
 
     /// Runs [`try_state_goal`] for each [`Item`].
@@ -195,7 +195,7 @@ where
     pub async fn current_and_goal(
         cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, E, O, PKeys, SetUp>>,
     ) -> Result<CmdOutcome<(StatesCurrent, StatesGoal), E>, E> {
-        Self::current_and_goal_with(&mut CmdIndependence::Standalone { cmd_ctx }, true).await
+        Self::current_and_goal_with(&mut cmd_ctx.as_standalone(), true).await
     }
 
     /// Runs [`try_state_current`] and [`try_state_goal`]` for each

--- a/crate/rt/src/cmds/states_discover_cmd.rs
+++ b/crate/rt/src/cmds/states_discover_cmd.rs
@@ -5,6 +5,7 @@ use peace_cfg::{FnCtx, ItemId};
 use peace_cmd::{
     ctx::CmdCtx,
     scopes::{SingleProfileSingleFlow, SingleProfileSingleFlowView},
+    CmdIndependence,
 };
 use peace_resources::{
     internal::StatesMut,
@@ -21,10 +22,7 @@ use peace_rt_model::{
     outcomes::CmdOutcome, output::OutputWrite, params::ParamsKeys, Error, Storage,
 };
 
-use crate::{
-    cmds::{cmd_ctx_internal::CmdIndependence, CmdBase},
-    BUFFERED_FUTURES_MAX,
-};
+use crate::{cmds::CmdBase, BUFFERED_FUTURES_MAX};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {

--- a/crate/rt/src/cmds/states_goal_read_cmd.rs
+++ b/crate/rt/src/cmds/states_goal_read_cmd.rs
@@ -5,6 +5,7 @@ use peace_cfg::{FlowId, ItemId};
 use peace_cmd::{
     ctx::CmdCtx,
     scopes::{SingleProfileSingleFlow, SingleProfileSingleFlowView},
+    CmdIndependence,
 };
 use peace_resources::{
     paths::{FlowDir, StatesGoalFile},
@@ -16,7 +17,7 @@ use peace_resources::{
 use peace_rt_model::{params::ParamsKeys, Error, StatesSerializer, Storage};
 use peace_rt_model_core::output::OutputWrite;
 
-use crate::cmds::{cmd_ctx_internal::CmdIndependence, CmdBase};
+use crate::cmds::CmdBase;
 
 /// Reads [`StatesGoalStored`]s from storage.
 #[derive(Debug)]

--- a/crate/rt/src/cmds/sub.rs
+++ b/crate/rt/src/cmds/sub.rs
@@ -5,6 +5,6 @@
 //!
 //! [`OutputWrite`]: peace_rt_model_core::OutputWrite
 
-pub use self::apply_cmd::{ApplyCmd, ApplyFor};
+pub use self::apply_cmd::{ApplyCmd, ApplyFor, ApplyStoredStateSync};
 
 mod apply_cmd;

--- a/crate/rt/src/cmds/sub/apply_cmd.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd.rs
@@ -5,6 +5,7 @@ use peace_cfg::{ApplyCheck, FnCtx, ItemId};
 use peace_cmd::{
     ctx::CmdCtx,
     scopes::{SingleProfileSingleFlow, SingleProfileSingleFlowView},
+    CmdIndependence,
 };
 use peace_params::ParamsSpecs;
 use peace_resources::{
@@ -24,10 +25,7 @@ use peace_rt_model_core::ItemsStateStoredStale;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    cmds::{
-        cmd_ctx_internal::CmdIndependence, CmdBase, StatesCurrentReadCmd, StatesDiscoverCmd,
-        StatesGoalReadCmd,
-    },
+    cmds::{CmdBase, StatesCurrentReadCmd, StatesDiscoverCmd, StatesGoalReadCmd},
     BUFFERED_FUTURES_MAX,
 };
 

--- a/crate/rt/src/cmds/sub/apply_cmd.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd.rs
@@ -576,8 +576,6 @@ where
     where
         StatesTs: Debug + Send + 'static,
     {
-        // TODO: don't store states during discovery, as we want the user to do this as
-        // an intentional operation.
         let states_current_outcome = StatesDiscoverCmd::<E, O, PKeys>::current_with(
             #[cfg(not(feature = "output_progress"))]
             &mut CmdIndependence::SubCmd { cmd_view },
@@ -586,6 +584,7 @@ where
                 cmd_view,
                 progress_tx: progress_tx.clone(),
             },
+            false,
         )
         .await;
         let states_current_outcome = match states_current_outcome {
@@ -649,8 +648,6 @@ where
     where
         StatesTs: Debug + Send + 'static,
     {
-        // TODO: don't store states during discovery, as we want the user to do this as
-        // an intentional operation.
         let states_goal_outcome = StatesDiscoverCmd::<E, O, PKeys>::goal_with(
             #[cfg(not(feature = "output_progress"))]
             &mut CmdIndependence::SubCmd { cmd_view },
@@ -659,6 +656,7 @@ where
                 cmd_view,
                 progress_tx: progress_tx.clone(),
             },
+            false,
         )
         .await;
         let states_goal_outcome = match states_goal_outcome {

--- a/crate/rt/src/cmds/sub/apply_cmd.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd.rs
@@ -611,12 +611,9 @@ where
     {
         let states_current_stored_result = StatesCurrentReadCmd::<E, O, PKeys>::exec_with(
             #[cfg(not(feature = "output_progress"))]
-            &mut CmdIndependence::SubCmd { cmd_view },
+            &mut cmd_view.as_sub_cmd(),
             #[cfg(feature = "output_progress")]
-            &mut CmdIndependence::SubCmdWithProgress {
-                cmd_view,
-                progress_tx: progress_tx.clone(),
-            },
+            &mut cmd_view.as_sub_cmd_with_progress(progress_tx.clone()),
         )
         .await;
         match states_current_stored_result {
@@ -640,12 +637,9 @@ where
     {
         let states_current_outcome = StatesDiscoverCmd::<E, O, PKeys>::current_with(
             #[cfg(not(feature = "output_progress"))]
-            &mut CmdIndependence::SubCmd { cmd_view },
+            &mut cmd_view.as_sub_cmd(),
             #[cfg(feature = "output_progress")]
-            &mut CmdIndependence::SubCmdWithProgress {
-                cmd_view,
-                progress_tx: progress_tx.clone(),
-            },
+            &mut cmd_view.as_sub_cmd_with_progress(progress_tx.clone()),
             false,
         )
         .await;
@@ -683,12 +677,9 @@ where
     {
         let states_goal_stored_result = StatesGoalReadCmd::<E, O, PKeys>::exec_with(
             #[cfg(not(feature = "output_progress"))]
-            &mut CmdIndependence::SubCmd { cmd_view },
+            &mut cmd_view.as_sub_cmd(),
             #[cfg(feature = "output_progress")]
-            &mut CmdIndependence::SubCmdWithProgress {
-                cmd_view,
-                progress_tx: progress_tx.clone(),
-            },
+            &mut cmd_view.as_sub_cmd_with_progress(progress_tx.clone()),
         )
         .await;
         match states_goal_stored_result {
@@ -712,12 +703,9 @@ where
     {
         let states_goal_outcome = StatesDiscoverCmd::<E, O, PKeys>::goal_with(
             #[cfg(not(feature = "output_progress"))]
-            &mut CmdIndependence::SubCmd { cmd_view },
+            &mut cmd_view.as_sub_cmd(),
             #[cfg(feature = "output_progress")]
-            &mut CmdIndependence::SubCmdWithProgress {
-                cmd_view,
-                progress_tx: progress_tx.clone(),
-            },
+            &mut cmd_view.as_sub_cmd_with_progress(progress_tx.clone()),
             false,
         )
         .await;

--- a/crate/rt/src/cmds/sub/apply_cmd.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd.rs
@@ -112,7 +112,7 @@ where
         apply_for: ApplyFor,
     ) -> Result<CmdOutcome<States<StatesTsApplyDry>, E>, E> {
         Self::exec_dry_with(
-            &mut CmdIndependence::Standalone { cmd_ctx },
+            &mut cmd_ctx.as_standalone(),
             apply_for,
             ApplyStoredStateSync::Both,
         )
@@ -183,7 +183,7 @@ where
         apply_for: ApplyFor,
     ) -> Result<CmdOutcome<States<StatesTsApply>, E>, E> {
         Self::exec_with(
-            &mut CmdIndependence::Standalone { cmd_ctx },
+            &mut cmd_ctx.as_standalone(),
             apply_for,
             ApplyStoredStateSync::Both,
         )

--- a/crate/rt/src/cmds/sub/apply_cmd/apply_stored_state_sync.rs
+++ b/crate/rt/src/cmds/sub/apply_cmd/apply_stored_state_sync.rs
@@ -1,0 +1,28 @@
+/// Whether to block an apply operation if stored states are not in sync with
+/// discovered state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApplyStoredStateSync {
+    /// Neither stored current states nor stored goal state need to be in sync
+    /// with the discovered current states and goal state.
+    None,
+    /// The stored current states must be in sync with the discovered current
+    /// state for the apply to proceed.
+    ///
+    /// The stored goal state does not need to be in sync with the discovered
+    /// goal state.
+    Current,
+    /// The stored goal state must be in sync with the discovered goal
+    /// state for the apply to proceed.
+    ///
+    /// The stored current states does not need to be in sync with the
+    /// discovered current state.
+    ///
+    /// For `CleanCmd`, this variant is equivalent to `None`.
+    Goal,
+    /// Both stored current states and stored goal state must be in sync with
+    /// the discovered current states and goal state for the apply to
+    /// proceed.
+    ///
+    /// For `CleanCmd`, this variant is equivalent to `Current`.
+    Both,
+}

--- a/crate/rt_model/src/item_rt.rs
+++ b/crate/rt_model/src/item_rt.rs
@@ -59,6 +59,24 @@ pub trait ItemRt<E>:
         states_type_reg: &mut StatesTypeReg,
     );
 
+    /// Returns if the given two states equal.
+    ///
+    /// This returns an error if the boxed states could not be downcasted to
+    /// this item's state, which indicates one of the following:
+    ///
+    /// * Peace contains a bug, and passed an incorrect box to this item.
+    /// * Item IDs were swapped, such that `ItemA`'s state is passed to `ItemB`.
+    ///
+    ///     This needs some rework on how item IDs are implemented -- as in,
+    ///     whether we should use a string newtype for `ItemId`s, or redesign
+    ///     how `Item`s or related types are keyed.
+    ///
+    /// Note: it is impossible to call this method if an `Item`'s state type has
+    /// changed -- it would have failed on deserialization.
+    fn state_eq(&self, state_a: &BoxDtDisplay, state_b: &BoxDtDisplay) -> Result<bool, E>
+    where
+        E: Debug + std::error::Error;
+
     /// Runs [`Item::state_clean`].
     ///
     /// [`Item::state_clean`]: peace_cfg::Item::state_clean

--- a/crate/rt_model_core/src/error.rs
+++ b/crate/rt_model_core/src/error.rs
@@ -4,8 +4,9 @@ use peace_core::{FlowId, ItemId, Profile};
 use peace_params::{ParamsResolveError, ParamsSpecs};
 use peace_resources::paths::{ItemParamsFile, ParamsSpecsFile};
 
-pub use self::state_downcast_error::StateDowncastError;
+pub use self::{apply_cmd_error::ApplyCmdError, state_downcast_error::StateDowncastError};
 
+mod apply_cmd_error;
 mod state_downcast_error;
 
 cfg_if::cfg_if! {
@@ -24,6 +25,19 @@ cfg_if::cfg_if! {
 #[cfg_attr(feature = "error_reporting", derive(miette::Diagnostic))]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Failed to apply changes.
+    #[error("Failed to apply changes.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(code(peace_rt_model::apply_error))
+    )]
+    ApplyCmdError(
+        #[cfg_attr(feature = "error_reporting", diagnostic_source)]
+        #[source]
+        #[from]
+        ApplyCmdError,
+    ),
+
     /// Failed to serialize error.
     #[error("Failed to serialize error.")]
     #[cfg_attr(

--- a/crate/rt_model_core/src/error.rs
+++ b/crate/rt_model_core/src/error.rs
@@ -4,6 +4,10 @@ use peace_core::{FlowId, ItemId, Profile};
 use peace_params::{ParamsResolveError, ParamsSpecs};
 use peace_resources::paths::{ItemParamsFile, ParamsSpecsFile};
 
+pub use self::state_downcast_error::StateDowncastError;
+
+mod state_downcast_error;
+
 cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
         pub use self::native_error::NativeError;
@@ -544,6 +548,15 @@ pub enum Error {
         /// Path to the file.
         path: PathBuf,
     },
+
+    /// Error downcasting a `BoxDtDisplay` into an item's concrete state type.
+    #[error("Error downcasting a `BoxDtDisplay` into an item's concrete state type.")]
+    StateDowncastError(
+        #[cfg_attr(feature = "error_reporting", diagnostic_source)]
+        #[source]
+        #[from]
+        StateDowncastError,
+    ),
 
     /// Native application error occurred.
     #[error("Native application error occurred.")]

--- a/crate/rt_model_core/src/error/apply_cmd_error.rs
+++ b/crate/rt_model_core/src/error/apply_cmd_error.rs
@@ -1,0 +1,36 @@
+/// Error applying changes to items.
+#[cfg_attr(feature = "error_reporting", derive(miette::Diagnostic))]
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyCmdError {
+    /// Stored current states were not up to date with actual current states.
+    #[error("Stored current states were not up to date with actual current states.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_rt_model::apply_cmd_error::states_current_out_of_sync),
+            help(
+                "\
+                Run `StatesDiscoverCmd::current` to update the stored current states,\n\
+                and re-check the difference before applying changes.\
+                "
+            ),
+        )
+    )]
+    StatesCurrentOutOfSync,
+
+    /// Stored goal states were not up to date with actual goal states.
+    #[error("Stored goal states were not up to date with actual goal states.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_rt_model::apply_cmd_error::states_goal_out_of_sync),
+            help(
+                "\
+                Run `StatesDiscoverCmd::goal` to update the stored goal states,\n\
+                and re-check the difference before applying changes.\
+                "
+            ),
+        )
+    )]
+    StatesGoalOutOfSync,
+}

--- a/crate/rt_model_core/src/error/apply_cmd_error.rs
+++ b/crate/rt_model_core/src/error/apply_cmd_error.rs
@@ -1,9 +1,16 @@
+use std::{fmt, fmt::Write};
+
+use crate::{ItemsStateStoredStale, StateStoredAndDiscovered};
+
 /// Error applying changes to items.
 #[cfg_attr(feature = "error_reporting", derive(miette::Diagnostic))]
 #[derive(Debug, thiserror::Error)]
 pub enum ApplyCmdError {
     /// Stored current states were not up to date with actual current states.
-    #[error("Stored current states were not up to date with actual current states.")]
+    #[error(
+        "Stored current states were not up to date with actual current states.\n\n{stale_states}",
+        stale_states = stale_states_fmt(items_state_stored_stale)?,
+    )]
     #[cfg_attr(
         feature = "error_reporting",
         diagnostic(
@@ -16,10 +23,17 @@ pub enum ApplyCmdError {
             ),
         )
     )]
-    StatesCurrentOutOfSync,
+    StatesCurrentOutOfSync {
+        /// Items whose stored current state is out of sync with the discovered
+        /// state.
+        items_state_stored_stale: ItemsStateStoredStale,
+    },
 
     /// Stored goal states were not up to date with actual goal states.
-    #[error("Stored goal states were not up to date with actual goal states.")]
+    #[error(
+        "Stored goal states were not up to date with actual goal states.\n\n{stale_states}",
+        stale_states = stale_states_fmt(items_state_stored_stale)?,
+    )]
     #[cfg_attr(
         feature = "error_reporting",
         diagnostic(
@@ -32,5 +46,42 @@ pub enum ApplyCmdError {
             ),
         )
     )]
-    StatesGoalOutOfSync,
+    StatesGoalOutOfSync {
+        /// Items whose stored goal state is out of sync with the discovered
+        /// state.
+        items_state_stored_stale: ItemsStateStoredStale,
+    },
+}
+
+fn stale_states_fmt(
+    items_state_stored_stale: &ItemsStateStoredStale,
+) -> Result<String, fmt::Error> {
+    let mut buffer = String::with_capacity(items_state_stored_stale.len() * 256);
+    items_state_stored_stale
+        .iter()
+        .try_for_each(|(item_id, state_stored_and_discovered)| {
+            writeln!(&mut buffer, "* {item_id}:\n")?;
+
+            match state_stored_and_discovered {
+                StateStoredAndDiscovered::OnlyStoredExists { state_stored } => {
+                    writeln!(&mut buffer, "    - stored: {state_stored:?}")?;
+                    writeln!(&mut buffer, "    - discovered: <none>\n")?;
+                }
+                StateStoredAndDiscovered::OnlyDiscoveredExists { state_discovered } => {
+                    writeln!(&mut buffer, "    - stored: <none>")?;
+                    writeln!(&mut buffer, "    - discovered: {state_discovered:?}\n")?;
+                }
+                StateStoredAndDiscovered::ValuesDiffer {
+                    state_stored,
+                    state_discovered,
+                } => {
+                    writeln!(&mut buffer, "    - stored: {state_stored:?}")?;
+                    writeln!(&mut buffer, "    - discovered: {state_discovered:?}\n")?;
+                }
+            }
+
+            Ok(())
+        })?;
+
+    Ok(buffer)
 }

--- a/crate/rt_model_core/src/error/state_downcast_error.rs
+++ b/crate/rt_model_core/src/error/state_downcast_error.rs
@@ -1,0 +1,110 @@
+use type_reg::untagged::{BoxDtDisplay, DataType};
+
+/// Error downcasting a `BoxDtDisplay` into an item's concrete state type.
+#[cfg_attr(feature = "error_reporting", derive(miette::Diagnostic))]
+#[derive(Debug, thiserror::Error)]
+pub enum StateDowncastError {
+    /// Both item states could not be downcasted.
+    #[error(
+        "Item states could not be downcasted to `{ty_name}`.\n\
+        Boxed type are:\n\
+        \n\
+        * `{boxed_ty_a:?}`.\n\
+        * `{boxed_ty_b:?}`.\n\
+        ",
+        ty_name = ty_name,
+        boxed_ty_a = state_a.type_name(),
+        boxed_ty_b = state_b.type_name(),
+    )]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_rt_model::state_downcast_error::both),
+            help(
+                "\
+                This error happens when the boxed states could not be downcasted to
+                this item's state, which indicates one of the following:\n\
+                \n\
+                * Peace contains a bug, and passed an incorrect box to this item.\n\
+                * Item IDs were swapped, such that `ItemA`'s state is passed to `ItemB`.\n\
+                \n\
+                This needs some rework on how item IDs are implemented -- as in,
+                whether we should use a string newtype for `ItemId`s, or redesign
+                how `Item`s or related types are keyed.\n\
+                "
+            ),
+        )
+    )]
+    Both {
+        /// Type name of the state type.
+        ty_name: String,
+        /// First state parameter.
+        state_a: BoxDtDisplay,
+        /// Second state parameter.
+        state_b: BoxDtDisplay,
+    },
+    /// First item state could not be downcasted.
+    #[error(
+        "First item state could not be downcasted to `{ty_name}`.\n\
+        Boxed type is `{boxed_ty:?}`.",
+        ty_name = ty_name,
+        boxed_ty = state_a.type_name(),
+    )]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_rt_model::state_downcast_error::first),
+            help(
+                "\
+                This error happens when the boxed states could not be downcasted to
+                this item's state, which indicates one of the following:\n\
+                \n\
+                * Peace contains a bug, and passed an incorrect box to this item.\n\
+                * Item IDs were swapped, such that `ItemA`'s state is passed to `ItemB`.\n\
+                \n\
+                This needs some rework on how item IDs are implemented -- as in,
+                whether we should use a string newtype for `ItemId`s, or redesign
+                how `Item`s or related types are keyed.\n\
+                "
+            ),
+        )
+    )]
+    First {
+        /// Type name of the state type.
+        ty_name: String,
+        /// First state parameter.
+        state_a: BoxDtDisplay,
+    },
+    /// Second item state could not be downcasted.
+    #[error(
+        "Second item state could not be downcasted to `{ty_name}`.\n\
+        Boxed type is `{boxed_ty:?}`.",
+        ty_name = ty_name,
+        boxed_ty = state_b.type_name(),
+    )]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_rt_model::state_downcast_error::second),
+            help(
+                "\
+                This error happens when the boxed states could not be downcasted to
+                this item's state, which indicates one of the following:\n\
+                \n\
+                * Peace contains a bug, and passed an incorrect box to this item.\n\
+                * Item IDs were swapped, such that `ItemA`'s state is passed to `ItemB`.\n\
+                \n\
+                This needs some rework on how item IDs are implemented -- as in,
+                whether we should use a string newtype for `ItemId`s, or redesign
+                how `Item`s or related types are keyed.\n\
+                "
+            ),
+        )
+    )]
+    Second {
+        /// Type name of the state type.
+        ty_name: String,
+        /// Second state parameter.
+        state_b: BoxDtDisplay,
+    },
+}

--- a/crate/rt_model_core/src/items_state_stored_stale.rs
+++ b/crate/rt_model_core/src/items_state_stored_stale.rs
@@ -1,0 +1,57 @@
+use std::ops::{Deref, DerefMut};
+
+use indexmap::IndexMap;
+use peace_core::ItemId;
+
+use crate::StateStoredAndDiscovered;
+
+/// Items whose stored and discovered state are not equal.
+///
+/// `IndexMap<ItemId, StateStoredAndDiscovered>` newtype.
+///
+/// This can be used for either current state or goal state.
+#[derive(Clone, Debug)]
+pub struct ItemsStateStoredStale(IndexMap<ItemId, StateStoredAndDiscovered>);
+
+impl ItemsStateStoredStale {
+    /// Returns a new `ItemsStateStoredStale` map.
+    pub fn new() -> Self {
+        Self(IndexMap::new())
+    }
+
+    /// Returns a new `ItemsStateStoredStale` map with the given preallocated
+    /// capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(IndexMap::with_capacity(capacity))
+    }
+
+    /// Returns the underlying map.
+    pub fn into_inner(self) -> IndexMap<ItemId, StateStoredAndDiscovered> {
+        self.0
+    }
+
+    /// Returns `true` if there is at least one stale stored state.
+    pub fn stale(&self) -> bool {
+        !self.0.is_empty()
+    }
+}
+
+impl Deref for ItemsStateStoredStale {
+    type Target = IndexMap<ItemId, StateStoredAndDiscovered>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ItemsStateStoredStale {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<(ItemId, StateStoredAndDiscovered)> for ItemsStateStoredStale {
+    fn from_iter<I: IntoIterator<Item = (ItemId, StateStoredAndDiscovered)>>(iter: I) -> Self {
+        Self(IndexMap::from_iter(iter))
+    }
+}

--- a/crate/rt_model_core/src/items_state_stored_stale.rs
+++ b/crate/rt_model_core/src/items_state_stored_stale.rs
@@ -10,7 +10,7 @@ use crate::StateStoredAndDiscovered;
 /// `IndexMap<ItemId, StateStoredAndDiscovered>` newtype.
 ///
 /// This can be used for either current state or goal state.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ItemsStateStoredStale(IndexMap<ItemId, StateStoredAndDiscovered>);
 
 impl ItemsStateStoredStale {

--- a/crate/rt_model_core/src/lib.rs
+++ b/crate/rt_model_core/src/lib.rs
@@ -12,7 +12,10 @@ pub use indicatif;
 pub mod output;
 pub mod params;
 
-pub use crate::{error::Error, item_params::ItemParams};
+pub use crate::{
+    error::{Error, StateDowncastError},
+    item_params::ItemParams,
+};
 
 mod error;
 mod item_params;

--- a/crate/rt_model_core/src/lib.rs
+++ b/crate/rt_model_core/src/lib.rs
@@ -15,10 +15,14 @@ pub mod params;
 pub use crate::{
     error::{ApplyCmdError, Error, StateDowncastError},
     item_params::ItemParams,
+    items_state_stored_stale::ItemsStateStoredStale,
+    state_stored_and_discovered::StateStoredAndDiscovered,
 };
 
 mod error;
 mod item_params;
+mod items_state_stored_stale;
+mod state_stored_and_discovered;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {

--- a/crate/rt_model_core/src/lib.rs
+++ b/crate/rt_model_core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod output;
 pub mod params;
 
 pub use crate::{
-    error::{Error, StateDowncastError},
+    error::{ApplyCmdError, Error, StateDowncastError},
     item_params::ItemParams,
 };
 

--- a/crate/rt_model_core/src/state_stored_and_discovered.rs
+++ b/crate/rt_model_core/src/state_stored_and_discovered.rs
@@ -1,0 +1,34 @@
+use type_reg::untagged::BoxDtDisplay;
+
+/// Stored and/or discovered state for an item.
+#[derive(Clone, Debug)]
+pub enum StateStoredAndDiscovered {
+    /// Stored state exists, but the actual item state cannot be discovered.
+    ///
+    /// These can probably be ignored during `CleanCmd`, for idempotence even if
+    /// a previous clean up did not complete successfully and stored states
+    /// were not updated.
+    OnlyStoredExists {
+        /// Stored current state or stored goal state.
+        state_stored: BoxDtDisplay,
+    },
+    /// No state was stored, but the actual item state exists.
+    ///
+    /// These can probably be ignored during `EnsureCmd`, for idempotence even
+    /// if a previous ensure did not complete successfully and stored states
+    /// were not updated.
+    OnlyDiscoveredExists {
+        /// Discovered current state or stored goal state during execution.
+        state_discovered: BoxDtDisplay,
+    },
+    /// Both stored state and discovered state exist.
+    ///
+    /// This variant is the one that users likely should be warned when ensuring
+    /// changes.
+    ValuesDiffer {
+        /// Stored current state or stored goal state.
+        state_stored: BoxDtDisplay,
+        /// Discovered current state or stored goal state during execution.
+        state_discovered: BoxDtDisplay,
+    },
+}

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -3,8 +3,8 @@ use peace::{
     cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow},
     resources::resources::ts::SetUp,
     rt::cmds::{
-        CleanCmd, DiffCmd, EnsureCmd, StatesCurrentReadCmd, StatesCurrentStoredDisplayCmd,
-        StatesDiscoverCmd, StatesGoalDisplayCmd,
+        CleanCmd, DiffCmd, EnsureCmd, StatesCurrentStoredDisplayCmd, StatesDiscoverCmd,
+        StatesGoalDisplayCmd,
     },
     rt_model::{
         outcomes::CmdOutcome,
@@ -149,8 +149,7 @@ pub async fn ensure_dry<O>(cmd_ctx: &mut DownloadCmdCtx<'_, O>) -> Result<(), Do
 where
     O: OutputWrite<DownloadError>,
 {
-    let states_current_stored = StatesCurrentReadCmd::exec(cmd_ctx).await?;
-    let states_ensured_dry_outcome = EnsureCmd::exec_dry(cmd_ctx, &states_current_stored).await?;
+    let states_ensured_dry_outcome = EnsureCmd::exec_dry(cmd_ctx).await?;
     let states_ensured_dry = &states_ensured_dry_outcome.value;
     cmd_ctx.output_mut().present(states_ensured_dry).await?;
     Ok(())
@@ -160,8 +159,7 @@ pub async fn ensure<O>(cmd_ctx: &mut DownloadCmdCtx<'_, O>) -> Result<(), Downlo
 where
     O: OutputWrite<DownloadError>,
 {
-    let states_current_stored = StatesCurrentReadCmd::exec(cmd_ctx).await?;
-    let states_ensured_outcome = EnsureCmd::exec(cmd_ctx, &states_current_stored).await?;
+    let states_ensured_outcome = EnsureCmd::exec(cmd_ctx).await?;
     let states_ensured = &states_ensured_outcome.value;
     cmd_ctx.output_mut().present(states_ensured).await?;
     Ok(())
@@ -171,8 +169,7 @@ pub async fn clean_dry<O>(cmd_ctx: &mut DownloadCmdCtx<'_, O>) -> Result<(), Dow
 where
     O: OutputWrite<DownloadError>,
 {
-    let states_current_stored = StatesCurrentReadCmd::exec(cmd_ctx).await?;
-    let states_cleaned_dry_outcome = CleanCmd::exec_dry(cmd_ctx, &states_current_stored).await?;
+    let states_cleaned_dry_outcome = CleanCmd::exec_dry(cmd_ctx).await?;
     let states_cleaned_dry = &states_cleaned_dry_outcome.value;
     cmd_ctx.output_mut().present(states_cleaned_dry).await?;
     Ok(())
@@ -182,8 +179,7 @@ pub async fn clean<O>(cmd_ctx: &mut DownloadCmdCtx<'_, O>) -> Result<(), Downloa
 where
     O: OutputWrite<DownloadError>,
 {
-    let states_current_stored = StatesCurrentReadCmd::exec(cmd_ctx).await?;
-    let states_cleaned_outcome = CleanCmd::exec(cmd_ctx, &states_current_stored).await?;
+    let states_cleaned_outcome = CleanCmd::exec(cmd_ctx).await?;
     let states_cleaned = &states_cleaned_outcome.value;
     cmd_ctx.output_mut().present(states_cleaned).await?;
     Ok(())

--- a/examples/envman/src/cmds/env_clean_cmd.rs
+++ b/examples/envman/src/cmds/env_clean_cmd.rs
@@ -2,7 +2,7 @@ use futures::FutureExt;
 use peace::{
     cmd::scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, CleanCmd},
+    rt::cmds::{ApplyStoredStateSync, CleanCmd},
     rt_model::{outcomes::CmdOutcome, output::OutputWrite},
 };
 
@@ -43,11 +43,9 @@ macro_rules! run {
     ($output:ident, $flow_cmd:ident, $padding:expr) => {{
         $flow_cmd::run($output, false, |cmd_ctx| {
             async move {
-                let states_cleaned_outcome = CleanCmd::exec_with(
-                    &mut CmdIndependence::Standalone { cmd_ctx },
-                    ApplyStoredStateSync::None,
-                )
-                .await?;
+                let states_cleaned_outcome =
+                    CleanCmd::exec_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::None)
+                        .await?;
                 let CmdOutcome {
                     value: states_cleaned,
                     errors,

--- a/examples/envman/src/cmds/env_clean_cmd.rs
+++ b/examples/envman/src/cmds/env_clean_cmd.rs
@@ -2,7 +2,7 @@ use futures::FutureExt;
 use peace::{
     cmd::scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{CleanCmd, StatesCurrentReadCmd},
+    rt::cmds::CleanCmd,
     rt_model::{outcomes::CmdOutcome, output::OutputWrite},
 };
 
@@ -41,14 +41,9 @@ impl EnvCleanCmd {
 
 macro_rules! run {
     ($output:ident, $flow_cmd:ident, $padding:expr) => {{
-        let states_current_stored = $flow_cmd::run($output, true, |ctx| {
-            StatesCurrentReadCmd::exec(ctx).boxed_local()
-        })
-        .await?;
         $flow_cmd::run($output, false, |ctx| {
             async move {
-                let states_current_stored_ref = &states_current_stored;
-                let states_cleaned_outcome = CleanCmd::exec(ctx, states_current_stored_ref).await?;
+                let states_cleaned_outcome = CleanCmd::exec(ctx).await?;
                 let CmdOutcome {
                     value: states_cleaned,
                     errors,

--- a/examples/envman/src/cmds/env_deploy_cmd.rs
+++ b/examples/envman/src/cmds/env_deploy_cmd.rs
@@ -1,8 +1,11 @@
 use futures::FutureExt;
 use peace::{
-    cmd::scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
+    cmd::{
+        scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
+        CmdIndependence,
+    },
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, EnsureCmd},
+    rt::cmds::{ApplyStoredStateSync, EnsureCmd},
     rt_model::{outcomes::CmdOutcome, output::OutputWrite},
 };
 

--- a/examples/envman/src/cmds/env_deploy_cmd.rs
+++ b/examples/envman/src/cmds/env_deploy_cmd.rs
@@ -2,7 +2,7 @@ use futures::FutureExt;
 use peace::{
     cmd::scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
-    rt::cmds::{EnsureCmd, StatesCurrentReadCmd},
+    rt::cmds::EnsureCmd,
     rt_model::{outcomes::CmdOutcome, output::OutputWrite},
 };
 
@@ -41,15 +41,9 @@ impl EnvDeployCmd {
 
 macro_rules! run {
     ($output:ident, $flow_cmd:ident, $padding:expr) => {{
-        let states_current_stored = $flow_cmd::run($output, true, |ctx| {
-            StatesCurrentReadCmd::exec(ctx).boxed_local()
-        })
-        .await?;
         $flow_cmd::run($output, false, |ctx| {
             async move {
-                let states_current_stored_ref = &states_current_stored;
-                let states_ensured_outcome =
-                    EnsureCmd::exec(ctx, states_current_stored_ref).await?;
+                let states_ensured_outcome = EnsureCmd::exec(ctx).await?;
                 let CmdOutcome {
                     value: states_ensured,
                     errors,

--- a/examples/envman/src/cmds/env_deploy_cmd.rs
+++ b/examples/envman/src/cmds/env_deploy_cmd.rs
@@ -45,7 +45,7 @@ macro_rules! run {
             async move {
                 let states_ensured_outcome = EnsureCmd::exec_with(
                     &mut CmdIndependence::Standalone { cmd_ctx },
-                    ApplyStoredStateSync::None,
+                    ApplyStoredStateSync::Current,
                 )
                 .await?;
                 let CmdOutcome {

--- a/examples/envman/src/cmds/env_deploy_cmd.rs
+++ b/examples/envman/src/cmds/env_deploy_cmd.rs
@@ -1,9 +1,6 @@
 use futures::FutureExt;
 use peace::{
-    cmd::{
-        scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
-        CmdIndependence,
-    },
+    cmd::scopes::{SingleProfileSingleFlowView, SingleProfileSingleFlowViewAndOutput},
     fmt::presentable::{Heading, HeadingLevel, ListNumbered},
     rt::cmds::{ApplyStoredStateSync, EnsureCmd},
     rt_model::{outcomes::CmdOutcome, output::OutputWrite},
@@ -47,7 +44,7 @@ macro_rules! run {
         $flow_cmd::run($output, false, |cmd_ctx| {
             async move {
                 let states_ensured_outcome = EnsureCmd::exec_with(
-                    &mut CmdIndependence::Standalone { cmd_ctx },
+                    &mut cmd_ctx.as_standalone(),
                     ApplyStoredStateSync::Current,
                 )
                 .await?;

--- a/examples/envman/src/items/peace_aws_s3_object/s3_object_state.rs
+++ b/examples/envman/src/items/peace_aws_s3_object/s3_object_state.rs
@@ -39,14 +39,14 @@ impl fmt::Display for S3ObjectState {
                         // https://s3.console.aws.amazon.com/s3/object/azriel-peace-envman-demo?prefix=web_app.tar
                         write!(
                             f,
-                            "uploaded at https://s3.console.aws.amazon.com/s3/object/{bucket_name}?prefix={object_key} "
+                            "uploaded at https://s3.console.aws.amazon.com/s3/object/{bucket_name}?prefix={object_key}"
                         )?;
                     }
                 }
                 if let Some(content_md5_hexstr) = content_md5_hexstr {
-                    write!(f, "(MD5: {content_md5_hexstr})")
+                    write!(f, " (MD5: {content_md5_hexstr})")
                 } else {
-                    write!(f, "(MD5 unknown)")
+                    write!(f, " (MD5 unknown)")
                 }
             }
         }

--- a/examples/envman/src/items/peace_aws_s3_object/s3_object_state_current_fn.rs
+++ b/examples/envman/src/items/peace_aws_s3_object/s3_object_state_current_fn.rs
@@ -85,7 +85,6 @@ where
                 let e_tag = head_object_output
                     .e_tag()
                     .expect("Expected S3 object e_tag to be Some when head_object is successful.")
-                    .trim_matches('"')
                     .to_string();
 
                 Some((content_md5_hexstr, e_tag))

--- a/items/file_download/src/file_download_state.rs
+++ b/items/file_download/src/file_download_state.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// This is used to represent the state of the source file, as well as the
 /// destination file.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FileDownloadState {
     /// File does not exist.
     None {
@@ -68,6 +68,82 @@ impl fmt::Display for FileDownloadState {
                 let path = path.display();
                 write!(f, "`{path}` (contents not tracked)")
             }
+        }
+    }
+}
+
+impl PartialEq for FileDownloadState {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                FileDownloadState::None { path: path_self },
+                FileDownloadState::None { path: path_other },
+            ) => path_self == path_other,
+            (
+                FileDownloadState::Unknown {
+                    path: path_self, ..
+                },
+                FileDownloadState::StringContents {
+                    path: path_other, ..
+                },
+            )
+            | (
+                FileDownloadState::Unknown {
+                    path: path_self, ..
+                },
+                FileDownloadState::Length {
+                    path: path_other, ..
+                },
+            )
+            | (
+                FileDownloadState::StringContents {
+                    path: path_self, ..
+                },
+                FileDownloadState::Unknown {
+                    path: path_other, ..
+                },
+            )
+            | (
+                FileDownloadState::Length {
+                    path: path_self, ..
+                },
+                FileDownloadState::Unknown {
+                    path: path_other, ..
+                },
+            )
+            | (
+                FileDownloadState::Unknown { path: path_self },
+                FileDownloadState::Unknown { path: path_other },
+            ) => path_self == path_other,
+
+            (FileDownloadState::Unknown { .. }, FileDownloadState::None { .. })
+            | (FileDownloadState::None { .. }, FileDownloadState::Unknown { .. })
+            | (FileDownloadState::None { .. }, FileDownloadState::StringContents { .. })
+            | (FileDownloadState::StringContents { .. }, FileDownloadState::None { .. })
+            | (FileDownloadState::StringContents { .. }, FileDownloadState::Length { .. })
+            | (FileDownloadState::Length { .. }, FileDownloadState::None { .. })
+            | (FileDownloadState::Length { .. }, FileDownloadState::StringContents { .. })
+            | (FileDownloadState::None { .. }, FileDownloadState::Length { .. }) => false,
+            (
+                FileDownloadState::StringContents {
+                    path: path_self,
+                    contents: contents_self,
+                },
+                FileDownloadState::StringContents {
+                    path: path_other,
+                    contents: contents_other,
+                },
+            ) => path_self == path_other && contents_self == contents_other,
+            (
+                FileDownloadState::Length {
+                    path: path_self,
+                    byte_count: byte_count_self,
+                },
+                FileDownloadState::Length {
+                    path: path_other,
+                    byte_count: byte_count_other,
+                },
+            ) => path_self == path_other && byte_count_self == byte_count_other,
         }
     }
 }

--- a/items/sh_cmd/src/sh_cmd_data.rs
+++ b/items/sh_cmd/src/sh_cmd_data.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
 use peace::{
-    data::{accessors::RMaybe, Data},
-    resources::states::StatesCurrentStored,
+    cfg::{accessors::Stored, State},
+    data::Data,
 };
+
+use crate::{ShCmdExecutionRecord, ShCmdState};
 
 /// Data used to run a shell command.
 ///
@@ -17,7 +19,7 @@ where
     Id: Send + Sync + 'static,
 {
     /// Stored states of this item's previous execution.
-    states_current_stored: RMaybe<'exec, StatesCurrentStored>,
+    state_current_stored: Stored<'exec, State<ShCmdState<Id>, ShCmdExecutionRecord>>,
 
     /// Marker.
     marker: PhantomData<Id>,
@@ -28,7 +30,7 @@ where
     Id: Send + Sync + 'static,
 {
     /// Returns the previous states.
-    pub fn states_current_stored(&self) -> Option<&StatesCurrentStored> {
-        self.states_current_stored.as_deref()
+    pub fn state_current_stored(&self) -> Option<&State<ShCmdState<Id>, ShCmdExecutionRecord>> {
+        self.state_current_stored.get()
     }
 }

--- a/items/sh_cmd/src/sh_cmd_execution_record.rs
+++ b/items/sh_cmd/src/sh_cmd_execution_record.rs
@@ -4,7 +4,7 @@ use chrono::{offset::Local, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Record of a shell command execution.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ShCmdExecutionRecord {
     /// There is no execution record.
     ///
@@ -42,6 +42,31 @@ impl fmt::Display for ShCmdExecutionRecord {
                 Some(code) => write!(f, "execution failed with code: {code}"),
                 None => write!(f, "execution was interrupted"),
             },
+        }
+    }
+}
+
+/// We don't compare timestamps of execution because we're concerned about
+/// state of whatever the shell command is reading, rather than when the shell
+/// command was run.
+impl PartialEq for ShCmdExecutionRecord {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ShCmdExecutionRecord::None, ShCmdExecutionRecord::None) => true,
+            (ShCmdExecutionRecord::None, ShCmdExecutionRecord::Some { .. })
+            | (ShCmdExecutionRecord::Some { .. }, ShCmdExecutionRecord::None) => false,
+            (
+                ShCmdExecutionRecord::Some {
+                    start_datetime: _,
+                    end_datetime: _,
+                    exit_code: exit_code_self,
+                },
+                ShCmdExecutionRecord::Some {
+                    start_datetime: _,
+                    end_datetime: _,
+                    exit_code: exit_code_other,
+                },
+            ) => exit_code_self == exit_code_other,
         }
     }
 }

--- a/items/sh_cmd/src/sh_cmd_state.rs
+++ b/items/sh_cmd/src/sh_cmd_state.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// * If the command has never been executed, this will be `None`.
 /// * If it has been executed, this is `Some(String)` captured from stdout.
-#[derive(Derivative, Serialize, Deserialize, PartialEq, Eq)]
-#[derivative(Clone, Debug)]
+#[derive(Derivative, Serialize, Deserialize, Eq)]
+#[derivative(Clone, Debug, PartialEq)]
 pub enum ShCmdState<Id> {
     /// The command is not executed.
     ///

--- a/workspace_tests/src/items/tar_x_item.rs
+++ b/workspace_tests/src/items/tar_x_item.rs
@@ -5,11 +5,8 @@ use peace::{
     cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlowView},
     data::Data,
     params::{ParamsSpec, ValueResolutionCtx, ValueResolutionMode},
-    resources::{
-        paths::{FlowDir, ProfileDir},
-        states::StatesCurrentStored,
-    },
-    rt::cmds::{CleanCmd, DiffCmd, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
+    resources::paths::{FlowDir, ProfileDir},
+    rt::cmds::{CleanCmd, DiffCmd, EnsureCmd, StatesDiscoverCmd},
     rt_model::{
         outcomes::CmdOutcome, Flow, InMemoryTextOutput, ItemGraph, ItemGraphBuilder, Workspace,
         WorkspaceSpec,
@@ -563,16 +560,12 @@ async fn ensure_unpacks_tar_when_files_not_exists() -> Result<(), Box<dyn std::e
             TarXParams::<TarXTest>::new(tar_path, dest).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     let CmdOutcome {
         value: states_ensured,
         errors: _,
-    } = EnsureCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
     let state_ensured = states_ensured
         .get::<FileMetadatas, _>(TarXTest::ID)
@@ -623,17 +616,13 @@ async fn ensure_removes_other_files_and_is_idempotent() -> Result<(), Box<dyn st
             TarXParams::<TarXTest>::new(tar_path, dest).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     // Overwrite changed files and remove extra files
     let CmdOutcome {
         value: states_ensured,
         errors: _,
-    } = EnsureCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
     let state_ensured = states_ensured
         .get::<FileMetadatas, _>(TarXTest::ID)
@@ -648,11 +637,10 @@ async fn ensure_removes_other_files_and_is_idempotent() -> Result<(), Box<dyn st
     );
 
     // Execute again to check idempotence
-    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
     let CmdOutcome {
         value: states_ensured,
         errors: _,
-    } = EnsureCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
     let state_ensured = states_ensured
         .get::<FileMetadatas, _>(TarXTest::ID)
@@ -691,16 +679,12 @@ async fn clean_removes_files_in_dest_directory() -> Result<(), Box<dyn std::erro
             TarXParams::<TarXTest>::new(tar_path, dest.clone()).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     let CmdOutcome {
         value: states_cleaned,
         errors: _,
-    } = CleanCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
+    } = CleanCmd::exec(&mut cmd_ctx).await?;
 
     let state_cleaned = states_cleaned
         .get::<FileMetadatas, _>(TarXTest::ID)

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -307,12 +307,12 @@ async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )
@@ -494,12 +494,12 @@ async fn exec_returns_sync_error_when_current_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -1,10 +1,10 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
-    cmd::ctx::CmdCtx,
+    cmd::{ctx::CmdCtx, CmdIndependence},
     resources::type_reg::untagged::BoxDataTypeDowncast,
     rt::cmds::{
-        cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, CleanCmd, EnsureCmd,
-        StatesCurrentReadCmd, StatesDiscoverCmd, StatesGoalReadCmd,
+        ApplyStoredStateSync, CleanCmd, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd,
+        StatesGoalReadCmd,
     },
     rt_model::{
         outcomes::CmdOutcome, ApplyCmdError, Error as PeaceRtError, Flow, ItemGraphBuilder,

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -1,6 +1,6 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
-    cmd::{ctx::CmdCtx, CmdIndependence},
+    cmd::ctx::CmdCtx,
     resources::type_reg::untagged::BoxDataTypeDowncast,
     rt::cmds::{
         ApplyStoredStateSync, CleanCmd, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd,
@@ -278,13 +278,8 @@ async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
         .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Dry-clean states.
-    let exec_dry_result = CleanCmd::exec_dry_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Current,
-    )
-    .await;
+    let exec_dry_result =
+        CleanCmd::exec_dry_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Current).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
@@ -373,13 +368,7 @@ async fn exec_dry_does_not_return_sync_error_when_goal_state_out_of_sync()
     let CmdOutcome {
         value: states_cleaned_dry,
         errors: _,
-    } = CleanCmd::exec_dry_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Goal,
-    )
-    .await?;
+    } = CleanCmd::exec_dry_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Goal).await?;
 
     // Re-read states from disk.
     let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
@@ -465,13 +454,8 @@ async fn exec_returns_sync_error_when_current_state_out_of_sync()
         .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Clean states.
-    let exec_result = CleanCmd::exec_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Current,
-    )
-    .await;
+    let exec_result =
+        CleanCmd::exec_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Current).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
@@ -560,13 +544,7 @@ async fn exec_does_not_return_sync_error_when_goal_state_out_of_sync()
     let CmdOutcome {
         value: states_cleaned,
         errors: _,
-    } = CleanCmd::exec_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Goal,
-    )
-    .await?;
+    } = CleanCmd::exec_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Goal).await?;
 
     // Re-read states from disk.
     let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -1,11 +1,19 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
     cmd::ctx::CmdCtx,
-    rt::cmds::{CleanCmd, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
-    rt_model::{outcomes::CmdOutcome, Flow, ItemGraphBuilder, Workspace, WorkspaceSpec},
+    rt::cmds::{
+        cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, CleanCmd, EnsureCmd,
+        StatesCurrentReadCmd, StatesDiscoverCmd, StatesGoalReadCmd,
+    },
+    rt_model::{
+        outcomes::CmdOutcome, ApplyCmdError, Error as PeaceRtError, Flow, ItemGraphBuilder,
+        Workspace, WorkspaceSpec,
+    },
 };
 
-use crate::{NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState};
+use crate::{
+    vec_copy_item::VecB, NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState,
+};
 
 #[tokio::test]
 async fn resources_cleaned_dry_does_not_alter_state_when_state_not_ensured()
@@ -89,16 +97,15 @@ async fn resources_cleaned_dry_does_not_alter_state_when_state_ensured()
         errors: _,
     } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
-    // Clean states.
+    // Dry-clean states.
     CleanCmd::exec_dry(&mut cmd_ctx).await?;
 
     // Re-read states from disk.
-    CleanCmd::exec_dry(&mut cmd_ctx).await?;
+    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
     let CmdOutcome {
         value: states_current,
         errors: _,
     } = StatesDiscoverCmd::current(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
@@ -217,6 +224,340 @@ async fn resources_cleaned_contains_state_cleaned_for_each_item_when_state_ensur
     assert_eq!(
         Some(VecCopyState::new()).as_ref(),
         states_current_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+    // Overwrite states current.
+    cmd_ctx
+        .resources_mut()
+        .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Dry-clean states.
+    let exec_dry_result = CleanCmd::exec_dry_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Current,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_dry_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesCurrentOutOfSync
+            )))
+        ),
+        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        but was {exec_dry_result:?}",
+    );
+
+    Ok(())
+}
+
+/// This should not return an error, because the target state for cleaning is
+/// not `state_goal`, but `state_clean`.
+#[tokio::test]
+async fn exec_dry_does_not_return_sync_error_when_goal_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+
+    // Dry-clean states.
+    let CmdOutcome {
+        value: states_cleaned_dry,
+        errors: _,
+    } = CleanCmd::exec_dry_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Goal,
+    )
+    .await?;
+
+    // Re-read states from disk.
+    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
+    let states_goal_stored = StatesGoalReadCmd::exec(&mut cmd_ctx).await?;
+    let CmdOutcome {
+        value: (states_current, states_goal),
+        errors: _,
+    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_current_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_current.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_goal_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::new()).as_ref(),
+        states_cleaned_dry.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_returns_sync_error_when_current_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+    // Overwrite states current.
+    cmd_ctx
+        .resources_mut()
+        .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Clean states.
+    let exec_result = CleanCmd::exec_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Current,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesCurrentOutOfSync
+            )))
+        ),
+        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        but was {exec_result:?}",
+    );
+
+    Ok(())
+}
+
+/// This should not return an error, because the target state for cleaning is
+/// not `state_goal`, but `state_clean`.
+#[tokio::test]
+async fn exec_does_not_return_sync_error_when_goal_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+
+    // Clean states.
+    let CmdOutcome {
+        value: states_cleaned,
+        errors: _,
+    } = CleanCmd::exec_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Goal,
+    )
+    .await?;
+
+    // Re-read states from disk.
+    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
+    let states_goal_stored = StatesGoalReadCmd::exec(&mut cmd_ctx).await?;
+    let CmdOutcome {
+        value: (states_current, states_goal),
+        errors: _,
+    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::new()).as_ref(),
+        states_current_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::new()).as_ref(),
+        states_current.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
+        states_goal_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(VecCopyState::new()).as_ref(),
+        states_cleaned.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
     );
 
     Ok(())

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,13 +1,14 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
     cmd::ctx::CmdCtx,
+    resources::type_reg::untagged::BoxDataTypeDowncast,
     rt::cmds::{
         cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, EnsureCmd, StatesCurrentReadCmd,
         StatesDiscoverCmd,
     },
     rt_model::{
         outcomes::CmdOutcome, ApplyCmdError, Error as PeaceRtError, Flow, ItemGraphBuilder,
-        Workspace, WorkspaceSpec,
+        StateStoredAndDiscovered, Workspace, WorkspaceSpec,
     },
 };
 
@@ -318,10 +319,30 @@ async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
         matches!(
             &exec_dry_result,
             Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
-                ApplyCmdError::StatesCurrentOutOfSync
+                ApplyCmdError::StatesCurrentOutOfSync { items_state_stored_stale }
             )))
+            if items_state_stored_stale.len() == 1
+            && matches!(
+                items_state_stored_stale.iter().next(),
+                Some((item_id, state_stored_and_discovered))
+                if item_id == VecCopyItem::ID_DEFAULT
+                && matches!(
+                    state_stored_and_discovered,
+                    StateStoredAndDiscovered::ValuesDiffer { state_stored, state_discovered }
+                    if matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
+                        Some(state_stored)
+                        if **state_stored == &[0, 1, 2, 3]
+                    )
+                    && matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
+                        Some(state_discovered)
+                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                    )
+                ),
+            )
         ),
-        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync {{ .. }} }})`,\n\
         but was {exec_dry_result:?}",
     );
 
@@ -388,10 +409,30 @@ async fn exec_dry_returns_sync_error_when_goal_state_out_of_sync()
         matches!(
             &exec_dry_result,
             Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
-                ApplyCmdError::StatesGoalOutOfSync
+                ApplyCmdError::StatesGoalOutOfSync { items_state_stored_stale }
             )))
+            if items_state_stored_stale.len() == 1
+            && matches!(
+                items_state_stored_stale.iter().next(),
+                Some((item_id, state_stored_and_discovered))
+                if item_id == VecCopyItem::ID_DEFAULT
+                && matches!(
+                    state_stored_and_discovered,
+                    StateStoredAndDiscovered::ValuesDiffer { state_stored, state_discovered }
+                    if matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
+                        Some(state_stored)
+                        if **state_stored == &[0, 1, 2, 3]
+                    )
+                    && matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
+                        Some(state_discovered)
+                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                    )
+                ),
+            )
         ),
-        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync }})`,\n\
+        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync {{ .. }} }})`,\n\
         but was {exec_dry_result:?}",
     );
 
@@ -462,10 +503,30 @@ async fn exec_returns_sync_error_when_current_state_out_of_sync()
         matches!(
             &exec_result,
             Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
-                ApplyCmdError::StatesCurrentOutOfSync
+                ApplyCmdError::StatesCurrentOutOfSync { items_state_stored_stale }
             )))
+            if items_state_stored_stale.len() == 1
+            && matches!(
+                items_state_stored_stale.iter().next(),
+                Some((item_id, state_stored_and_discovered))
+                if item_id == VecCopyItem::ID_DEFAULT
+                && matches!(
+                    state_stored_and_discovered,
+                    StateStoredAndDiscovered::ValuesDiffer { state_stored, state_discovered }
+                    if matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
+                        Some(state_stored)
+                        if **state_stored == &[0, 1, 2, 3]
+                    )
+                    && matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
+                        Some(state_discovered)
+                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                    )
+                ),
+            )
         ),
-        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync {{ .. }} }})`,\n\
         but was {exec_result:?}",
     );
 
@@ -532,10 +593,30 @@ async fn exec_returns_sync_error_when_goal_state_out_of_sync()
         matches!(
             &exec_result,
             Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
-                ApplyCmdError::StatesGoalOutOfSync
+                ApplyCmdError::StatesGoalOutOfSync { items_state_stored_stale }
             )))
+            if items_state_stored_stale.len() == 1
+            && matches!(
+                items_state_stored_stale.iter().next(),
+                Some((item_id, state_stored_and_discovered))
+                if item_id == VecCopyItem::ID_DEFAULT
+                && matches!(
+                    state_stored_and_discovered,
+                    StateStoredAndDiscovered::ValuesDiffer { state_stored, state_discovered }
+                    if matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
+                        Some(state_stored)
+                        if **state_stored == &[0, 1, 2, 3]
+                    )
+                    && matches!(
+                        BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
+                        Some(state_discovered)
+                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                    )
+                ),
+            )
         ),
-        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync }})`,\n\
+        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync {{ .. }} }})`,\n\
         but was {exec_result:?}",
     );
 

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,11 +1,19 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
     cmd::ctx::CmdCtx,
-    rt::cmds::{EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
-    rt_model::{outcomes::CmdOutcome, Flow, ItemGraphBuilder, Workspace, WorkspaceSpec},
+    rt::cmds::{
+        cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, EnsureCmd, StatesCurrentReadCmd,
+        StatesDiscoverCmd,
+    },
+    rt_model::{
+        outcomes::CmdOutcome, ApplyCmdError, Error as PeaceRtError, Flow, ItemGraphBuilder,
+        Workspace, WorkspaceSpec,
+    },
 };
 
-use crate::{NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState};
+use crate::{
+    vec_copy_item::VecB, NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState,
+};
 
 #[tokio::test]
 async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std::error::Error>> {
@@ -191,9 +199,11 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_alrea
         .with_flow(&flow)
         .with_item_params::<VecCopyItem>(
             VecCopyItem::ID_DEFAULT.clone(),
-            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+            VecA(vec![0, 1, 2, 3]).into(),
         )
         .await?;
+    // Changing params changes VecCopyItem state_goal
+    StatesDiscoverCmd::goal(&mut cmd_ctx).await?;
     let CmdOutcome {
         value: ensured_states_ensured_dry,
         errors: _,
@@ -233,12 +243,300 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_alrea
         ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
     ); // states_ensured.logical should be the same as goal states, if all went well.
     assert_eq!(
-        Some(VecCopyState::from(vec![0u8, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
         ensured_states_ensured_dry.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
     ); // TODO: EnsureDry state should simulate the actual states, not return the actual current state
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
         states_current_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+    // Overwrite states current.
+    cmd_ctx
+        .resources_mut()
+        .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Dry ensure states.
+    let exec_dry_result = EnsureCmd::exec_dry_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Current,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_dry_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesCurrentOutOfSync
+            )))
+        ),
+        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        but was {exec_dry_result:?}",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_dry_returns_sync_error_when_goal_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+
+    // Dry ensure states.
+    let exec_dry_result = EnsureCmd::exec_dry_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Goal,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_dry_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesGoalOutOfSync
+            )))
+        ),
+        "Expected `exec_dry_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync }})`,\n\
+        but was {exec_dry_result:?}",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_returns_sync_error_when_current_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+    // Overwrite states current.
+    cmd_ctx
+        .resources_mut()
+        .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
+
+    // Ensure states.
+    let exec_result = EnsureCmd::exec_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Current,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesCurrentOutOfSync
+            )))
+        ),
+        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesCurrentOutOfSync }})`,\n\
+        but was {exec_result:?}",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn exec_returns_sync_error_when_goal_state_out_of_sync()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    // Write current and goal states to disk.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
+
+    // Alter states.
+    let CmdOutcome {
+        value: ensured_states_ensured,
+        errors: _,
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
+
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+
+    // Ensure states.
+    let exec_result = EnsureCmd::exec_with(
+        &mut CmdIndependence::Standalone {
+            cmd_ctx: &mut cmd_ctx,
+        },
+        ApplyStoredStateSync::Goal,
+    )
+    .await;
+
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
+        ensured_states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert!(
+        matches!(
+            &exec_result,
+            Err(PeaceTestError::PeaceRt(PeaceRtError::ApplyCmdError(
+                ApplyCmdError::StatesGoalOutOfSync
+            )))
+        ),
+        "Expected `exec_result` to be `Err(.. {{ ApplyCmdError::StatesGoalOutOfSync }})`,\n\
+        but was {exec_result:?}",
     );
 
     Ok(())

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,6 +1,6 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
-    cmd::{ctx::CmdCtx, CmdIndependence},
+    cmd::ctx::CmdCtx,
     resources::type_reg::untagged::BoxDataTypeDowncast,
     rt::cmds::{ApplyStoredStateSync, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
     rt_model::{
@@ -300,13 +300,8 @@ async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
         .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Dry ensure states.
-    let exec_dry_result = EnsureCmd::exec_dry_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Current,
-    )
-    .await;
+    let exec_dry_result =
+        EnsureCmd::exec_dry_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Current).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
@@ -390,13 +385,8 @@ async fn exec_dry_returns_sync_error_when_goal_state_out_of_sync()
         .await?;
 
     // Dry ensure states.
-    let exec_dry_result = EnsureCmd::exec_dry_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Goal,
-    )
-    .await;
+    let exec_dry_result =
+        EnsureCmd::exec_dry_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Goal).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
@@ -484,13 +474,8 @@ async fn exec_returns_sync_error_when_current_state_out_of_sync()
         .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
 
     // Ensure states.
-    let exec_result = EnsureCmd::exec_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Current,
-    )
-    .await;
+    let exec_result =
+        EnsureCmd::exec_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Current).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),
@@ -574,13 +559,8 @@ async fn exec_returns_sync_error_when_goal_state_out_of_sync()
         .await?;
 
     // Ensure states.
-    let exec_result = EnsureCmd::exec_with(
-        &mut CmdIndependence::Standalone {
-            cmd_ctx: &mut cmd_ctx,
-        },
-        ApplyStoredStateSync::Goal,
-    )
-    .await;
+    let exec_result =
+        EnsureCmd::exec_with(&mut cmd_ctx.as_standalone(), ApplyStoredStateSync::Goal).await;
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3])).as_ref(),

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -332,12 +332,12 @@ async fn exec_dry_returns_sync_error_when_current_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )
@@ -422,12 +422,12 @@ async fn exec_dry_returns_sync_error_when_goal_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )
@@ -516,12 +516,12 @@ async fn exec_returns_sync_error_when_current_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )
@@ -606,12 +606,12 @@ async fn exec_returns_sync_error_when_goal_state_out_of_sync()
                     if matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_stored),
                         Some(state_stored)
-                        if **state_stored == &[0, 1, 2, 3]
+                        if **state_stored == [0, 1, 2, 3]
                     )
                     && matches!(
                         BoxDataTypeDowncast::<VecCopyState>::downcast_ref(state_discovered),
                         Some(state_discovered)
-                        if **state_discovered == &[0, 1, 2, 3, 4, 5, 6, 7]
+                        if **state_discovered == [0, 1, 2, 3, 4, 5, 6, 7]
                     )
                 ),
             )

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,11 +1,8 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
-    cmd::ctx::CmdCtx,
+    cmd::{ctx::CmdCtx, CmdIndependence},
     resources::type_reg::untagged::BoxDataTypeDowncast,
-    rt::cmds::{
-        cmd_ctx_internal::CmdIndependence, ApplyStoredStateSync, EnsureCmd, StatesCurrentReadCmd,
-        StatesDiscoverCmd,
-    },
+    rt::cmds::{ApplyStoredStateSync, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
     rt_model::{
         outcomes::CmdOutcome, ApplyCmdError, Error as PeaceRtError, Flow, ItemGraphBuilder,
         StateStoredAndDiscovered, Workspace, WorkspaceSpec,

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,7 +1,6 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, Profile},
     cmd::ctx::CmdCtx,
-    resources::states::StatesCurrentStored,
     rt::cmds::{EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd},
     rt_model::{outcomes::CmdOutcome, Flow, ItemGraphBuilder, Workspace, WorkspaceSpec},
 };
@@ -32,11 +31,7 @@ async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std:
             VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     // Dry-ensured states.
     // The returned states are currently the same as `StatesCurrentStored`, but it
@@ -44,7 +39,7 @@ async fn resources_ensured_dry_does_not_alter_state() -> Result<(), Box<dyn std:
     let CmdOutcome {
         value: states_ensured_dry,
         errors: _,
-    } = EnsureCmd::exec_dry(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec_dry(&mut cmd_ctx).await?;
 
     // TODO: When EnsureCmd returns the execution report, assert on the state that
     // was discovered.
@@ -97,11 +92,7 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_not_y
             VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     // Alter states.
     let mut output = NoOpOutput;
@@ -116,7 +107,7 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_not_y
     let CmdOutcome {
         value: ensured_states_ensured,
         errors: _,
-    } = EnsureCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
     // Re-read states from disk.
     let mut output = NoOpOutput;
@@ -185,18 +176,13 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_alrea
             VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
         )
         .await?;
-    let CmdOutcome {
-        value: (states_current, _states_goal),
-        errors: _,
-    } = StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
-    let states_current_stored = StatesCurrentStored::from(states_current);
+    StatesDiscoverCmd::current_and_goal(&mut cmd_ctx).await?;
 
     // Alter states.
     let CmdOutcome {
         value: ensured_states_ensured,
         errors: _,
-    } = EnsureCmd::exec(&mut cmd_ctx, &states_current_stored).await?;
-    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
+    } = EnsureCmd::exec(&mut cmd_ctx).await?;
 
     // Dry ensure states.
     let mut output = NoOpOutput;
@@ -211,7 +197,7 @@ async fn resources_ensured_contains_state_ensured_for_each_item_when_state_alrea
     let CmdOutcome {
         value: ensured_states_ensured_dry,
         errors: _,
-    } = EnsureCmd::exec_dry(&mut cmd_ctx, &states_current_stored).await?;
+    } = EnsureCmd::exec_dry(&mut cmd_ctx).await?;
 
     // Re-read states from disk.
     let mut output = NoOpOutput;

--- a/workspace_tests/src/rt/cmds/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_discover_cmd.rs
@@ -6,11 +6,16 @@ use peace::{
         states::{StatesCurrent, StatesCurrentStored, StatesGoal},
         type_reg::untagged::{BoxDtDisplay, TypeReg},
     },
-    rt::cmds::StatesDiscoverCmd,
+    rt::cmds::{
+        cmd_ctx_internal::CmdIndependence, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd,
+        StatesGoalReadCmd,
+    },
     rt_model::{outcomes::CmdOutcome, Flow, ItemGraphBuilder, Workspace, WorkspaceSpec},
 };
 
-use crate::{NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState};
+use crate::{
+    vec_copy_item::VecB, NoOpOutput, PeaceTestError, VecA, VecCopyError, VecCopyItem, VecCopyState,
+};
 
 #[tokio::test]
 async fn current_and_goal_discovers_both_states_current_and_goal()
@@ -237,6 +242,147 @@ async fn goal_runs_state_goal_for_each_item() -> Result<(), Box<dyn std::error::
     assert_eq!(
         states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT),
         states_goal_on_disk.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn current_with_does_not_serialize_states_when_told_not_to()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+
+    // Write to disk first.
+    assert!(
+        StatesDiscoverCmd::current_and_goal(&mut cmd_ctx)
+            .await?
+            .is_ok()
+    );
+    assert!(EnsureCmd::exec(&mut cmd_ctx).await?.is_ok());
+
+    // Discover without serializing to storage.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .await?;
+    // Overwrite states current.
+    cmd_ctx
+        .resources_mut()
+        .insert(VecB(vec![0, 1, 2, 3, 4, 5, 6, 7]));
+
+    let CmdOutcome {
+        value: states_current,
+        errors: _,
+    } = StatesDiscoverCmd::<_, NoOpOutput, _>::current_with(
+        &mut CmdIndependence::SubCmd {
+            cmd_view: &mut cmd_ctx.view(),
+        },
+        false,
+    )
+    .await?;
+
+    let vec_copy_state = states_current.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT);
+    let states_current_stored = StatesCurrentReadCmd::exec(&mut cmd_ctx).await?;
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        vec_copy_state
+    );
+    assert_eq!(
+        Some(&VecCopyState::from(vec![0, 1, 2, 3])),
+        states_current_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(&VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])),
+        states_current.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT),
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn goal_with_does_not_serialize_states_when_told_not_to()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        graph_builder.add_fn(VecCopyItem::default().into());
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3]).into(),
+        )
+        .await?;
+
+    // Write to disk first.
+    assert!(
+        StatesDiscoverCmd::current_and_goal(&mut cmd_ctx)
+            .await?
+            .is_ok()
+    );
+
+    // Discover without serializing to storage.
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .await?;
+
+    let CmdOutcome {
+        value: states_goal,
+        errors: _,
+    } = StatesDiscoverCmd::<_, NoOpOutput, _>::goal_with(
+        &mut CmdIndependence::SubCmd {
+            cmd_view: &mut cmd_ctx.view(),
+        },
+        false,
+    )
+    .await?;
+
+    let vec_copy_state = states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT);
+    let states_goal_stored = StatesGoalReadCmd::exec(&mut cmd_ctx).await?;
+    assert_eq!(
+        Some(VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        vec_copy_state
+    );
+    assert_eq!(
+        Some(&VecCopyState::from(vec![0, 1, 2, 3])),
+        states_goal_stored.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(&VecCopyState::from(vec![0, 1, 2, 3, 4, 5, 6, 7])),
+        states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT),
     );
 
     Ok(())

--- a/workspace_tests/src/rt/cmds/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_discover_cmd.rs
@@ -1,15 +1,12 @@
 use peace::{
     cfg::{app_name, profile, AppName, FlowId, ItemId, Profile},
-    cmd::ctx::CmdCtx,
+    cmd::{ctx::CmdCtx, CmdIndependence},
     resources::{
         paths::{StatesCurrentFile, StatesGoalFile},
         states::{StatesCurrent, StatesCurrentStored, StatesGoal},
         type_reg::untagged::{BoxDtDisplay, TypeReg},
     },
-    rt::cmds::{
-        cmd_ctx_internal::CmdIndependence, EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd,
-        StatesGoalReadCmd,
-    },
+    rt::cmds::{EnsureCmd, StatesCurrentReadCmd, StatesDiscoverCmd, StatesGoalReadCmd},
     rt_model::{outcomes::CmdOutcome, Flow, ItemGraphBuilder, Workspace, WorkspaceSpec},
 };
 


### PR DESCRIPTION
Closes #59.

This allows developers to control whether out-of-sync states indicates execution should stop, or continue by design.