### PR TITLE
Store `ItemStreamOutcome` instead of `StreamOutcome` in `CmdOutcome`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 * Change `CmdOutcome` to be an `enum` indicating whether it is completed, interrupted, or erroneous. ([#141], [#163])
 * Add `CmdBlock` trait to encompass one function for all items. ([#141], [#163])
 * Add interruptibility support using [`interruptible`] through `CmdCtxBuilder::with_interruptibility`. ([#141], [#163])
+* Add `ItemStreamOutcome` to track which `Item`s are processed or not processed. ([#164], [#165])
 
 
 [`interruptible`]: https://github.com/azriel91/interruptible
 [#141]: https://github.com/azriel91/peace/issues/141
 [#163]: https://github.com/azriel91/peace/pull/163
+[#164]: https://github.com/azriel91/peace/issues/164
+[#165]: https://github.com/azriel91/peace/pull/165
 
 
 ## 0.0.11 (2023-06-27)

--- a/crate/cmd_model/src/item_stream_outcome.rs
+++ b/crate/cmd_model/src/item_stream_outcome.rs
@@ -1,0 +1,132 @@
+use fn_graph::StreamOutcomeState;
+use peace_cfg::ItemId;
+
+/// How a `Flow` stream operation ended and IDs that were processed.
+///
+/// Currently this is constructed by `ItemStreamOutcomeMapper`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ItemStreamOutcome<T> {
+    /// The value of the outcome.
+    pub value: T,
+    /// How a `Flow` stream operation ended.
+    pub state: StreamOutcomeState,
+    /// IDs of the items that were processed.
+    pub item_ids_processed: Vec<ItemId>,
+    /// IDs of the items that were not processed.
+    pub item_ids_not_processed: Vec<ItemId>,
+}
+
+impl<T> ItemStreamOutcome<T> {
+    /// Returns an `ItemStreamOutcome` that is `Finished<T>`.
+    pub fn finished_with(value: T, item_ids_processed: Vec<ItemId>) -> Self {
+        Self {
+            value,
+            state: StreamOutcomeState::Finished,
+            item_ids_processed,
+            item_ids_not_processed: Vec::new(),
+        }
+    }
+
+    /// Maps this outcome's value to another.
+    pub fn map<TNew>(self, f: impl FnOnce(T) -> TNew) -> ItemStreamOutcome<TNew> {
+        let ItemStreamOutcome {
+            value,
+            state,
+            item_ids_processed,
+            item_ids_not_processed,
+        } = self;
+
+        let value = f(value);
+
+        ItemStreamOutcome {
+            value,
+            state,
+            item_ids_processed,
+            item_ids_not_processed,
+        }
+    }
+
+    /// Replaces the value from this outcome with another.
+    pub fn replace<TNew>(self, value_new: TNew) -> (ItemStreamOutcome<TNew>, T) {
+        let ItemStreamOutcome {
+            value: value_existing,
+            state,
+            item_ids_processed,
+            item_ids_not_processed,
+        } = self;
+
+        (
+            ItemStreamOutcome {
+                value: value_new,
+                state,
+                item_ids_processed,
+                item_ids_not_processed,
+            },
+            value_existing,
+        )
+    }
+
+    /// Replaces the value from this outcome with another, taking the current
+    /// value as a parameter.
+    pub fn replace_with<TNew, U>(
+        self,
+        f: impl FnOnce(T) -> (TNew, U),
+    ) -> (ItemStreamOutcome<TNew>, U) {
+        let ItemStreamOutcome {
+            value,
+            state,
+            item_ids_processed,
+            item_ids_not_processed,
+        } = self;
+
+        let (value, extracted) = f(value);
+
+        (
+            ItemStreamOutcome {
+                value,
+                state,
+                item_ids_processed,
+                item_ids_not_processed,
+            },
+            extracted,
+        )
+    }
+
+    pub fn into_value(self) -> T {
+        self.value
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    pub fn state(&self) -> StreamOutcomeState {
+        self.state
+    }
+
+    pub fn item_ids_processed(&self) -> &[ItemId] {
+        self.item_ids_processed.as_ref()
+    }
+
+    pub fn item_ids_not_processed(&self) -> &[ItemId] {
+        self.item_ids_not_processed.as_ref()
+    }
+}
+
+impl<T> Default for ItemStreamOutcome<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            value: T::default(),
+            state: StreamOutcomeState::NotStarted,
+            item_ids_processed: Vec::new(),
+            item_ids_not_processed: Vec::new(),
+        }
+    }
+}

--- a/crate/cmd_model/src/lib.rs
+++ b/crate/cmd_model/src/lib.rs
@@ -9,7 +9,7 @@ pub use indexmap;
 pub use crate::{
     cmd_block_desc::CmdBlockDesc, cmd_block_outcome::CmdBlockOutcome,
     cmd_execution_error::CmdExecutionError, cmd_outcome::CmdOutcome,
-    stream_outcome_and_errors::StreamOutcomeAndErrors,
+    item_stream_outcome::ItemStreamOutcome, stream_outcome_and_errors::StreamOutcomeAndErrors,
     value_and_stream_outcome::ValueAndStreamOutcome,
 };
 
@@ -17,5 +17,6 @@ mod cmd_block_desc;
 mod cmd_block_outcome;
 mod cmd_execution_error;
 mod cmd_outcome;
+mod item_stream_outcome;
 mod stream_outcome_and_errors;
 mod value_and_stream_outcome;

--- a/crate/cmd_rt/src/item_stream_outcome_mapper.rs
+++ b/crate/cmd_rt/src/item_stream_outcome_mapper.rs
@@ -1,0 +1,60 @@
+use fn_graph::StreamOutcome;
+use peace_cmd_model::ItemStreamOutcome;
+use peace_rt_model::Flow;
+
+/// Maps a `StreamOutcome<T>` to an `ItemStreamOutcome<T>`.
+///
+/// # Design Note
+///
+/// This resides in the `cmd_rt` package as the `Flow` type is needed for
+/// mapping, and adding `rt_model` as a dependency of `cmd_model` creates a
+/// dependency cycle with `rt_model_core`:
+///
+/// ```text
+/// cmd_model -> rt_model
+///    ^         /
+///   /         v
+/// rt_model_core
+/// ```
+pub struct ItemStreamOutcomeMapper;
+
+impl ItemStreamOutcomeMapper {
+    /// Maps `FnId`s into `ItemId`s for a better information abstraction level.
+    pub fn map<T, E>(flow: &Flow<E>, stream_outcome: StreamOutcome<T>) -> ItemStreamOutcome<T>
+    where
+        E: 'static,
+    {
+        let StreamOutcome {
+            value,
+            state,
+            fn_ids_processed,
+            fn_ids_not_processed,
+        } = stream_outcome;
+
+        let item_ids_processed = fn_ids_processed
+            .into_iter()
+            .filter_map(|fn_id| {
+                flow.graph()
+                    .node_weight(fn_id)
+                    .map(|item| item.id())
+                    .cloned()
+            })
+            .collect::<Vec<_>>();
+        let item_ids_not_processed = fn_ids_not_processed
+            .into_iter()
+            .filter_map(|fn_id| {
+                flow.graph()
+                    .node_weight(fn_id)
+                    .map(|item| item.id())
+                    .cloned()
+            })
+            .collect::<Vec<_>>();
+
+        ItemStreamOutcome {
+            value,
+            state,
+            item_ids_processed,
+            item_ids_not_processed,
+        }
+    }
+}

--- a/crate/cmd_rt/src/lib.rs
+++ b/crate/cmd_rt/src/lib.rs
@@ -7,10 +7,12 @@ pub use tynm;
 pub use crate::{
     cmd_block::{CmdBlock, CmdBlockError, CmdBlockRt, CmdBlockRtBox, CmdBlockWrapper},
     cmd_execution::{CmdExecution, CmdExecutionBuilder},
+    item_stream_outcome_mapper::ItemStreamOutcomeMapper,
 };
 
 mod cmd_block;
 mod cmd_execution;
+mod item_stream_outcome_mapper;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "output_progress")] {

--- a/examples/envman/src/cmds/env_clean_cmd.rs
+++ b/examples/envman/src/cmds/env_clean_cmd.rs
@@ -98,7 +98,7 @@ where
             .await?;
     }
 
-    crate::output::cmd_outcome_completion_present(output, flow, resources, states_cleaned_outcome)
+    crate::output::cmd_outcome_completion_present(output, resources, states_cleaned_outcome)
         .await?;
 
     Ok(())

--- a/examples/envman/src/cmds/env_deploy_cmd.rs
+++ b/examples/envman/src/cmds/env_deploy_cmd.rs
@@ -98,7 +98,7 @@ where
             .await?;
     }
 
-    crate::output::cmd_outcome_completion_present(output, flow, resources, states_ensured_outcome)
+    crate::output::cmd_outcome_completion_present(output, resources, states_ensured_outcome)
         .await?;
 
     Ok(())

--- a/examples/envman/src/cmds/env_discover_cmd.rs
+++ b/examples/envman/src/cmds/env_discover_cmd.rs
@@ -120,7 +120,7 @@ where
             .await?;
     }
 
-    crate::output::cmd_outcome_completion_present(output, flow, resources, states_discover_outcome)
+    crate::output::cmd_outcome_completion_present(output, resources, states_discover_outcome)
         .await?;
 
     Ok(())

--- a/examples/envman/src/cmds/profile_init_cmd.rs
+++ b/examples/envman/src/cmds/profile_init_cmd.rs
@@ -180,7 +180,7 @@ impl ProfileInitCmd {
                 );
             }
             CmdOutcome::ItemError {
-                stream_outcome: _,
+                item_stream_outcome: _,
                 cmd_blocks_processed: _,
                 cmd_blocks_not_processed: _,
                 errors,

--- a/workspace_tests/src/cmd_model.rs
+++ b/workspace_tests/src/cmd_model.rs
@@ -1,2 +1,3 @@
 mod cmd_block_outcome;
 mod cmd_outcome;
+mod item_stream_outcome;

--- a/workspace_tests/src/cmd_model/cmd_outcome.rs
+++ b/workspace_tests/src/cmd_model/cmd_outcome.rs
@@ -1,6 +1,6 @@
 use peace::{
-    cmd_model::CmdOutcome,
-    rt_model::{fn_graph::StreamOutcome, IndexMap},
+    cmd_model::{CmdOutcome, ItemStreamOutcome},
+    rt_model::IndexMap,
 };
 
 #[test]
@@ -167,7 +167,7 @@ fn cmd_outcome_complete<T>(value: T) -> CmdOutcome<T, String> {
 
 fn cmd_outcome_block_interrupted<T>(value: T) -> CmdOutcome<T, String> {
     CmdOutcome::<T, String>::BlockInterrupted {
-        stream_outcome: StreamOutcome::finished_with(value, Vec::new()),
+        item_stream_outcome: ItemStreamOutcome::finished_with(value, Vec::new()),
         cmd_blocks_processed: vec![],
         cmd_blocks_not_processed: vec![],
     }
@@ -183,7 +183,7 @@ fn cmd_outcome_execution_interrupted<T>(value: Option<T>) -> CmdOutcome<T, Strin
 
 fn cmd_outcome_item_error<T>(value: T) -> CmdOutcome<T, String> {
     CmdOutcome::<T, String>::ItemError {
-        stream_outcome: StreamOutcome::finished_with(value, Vec::new()),
+        item_stream_outcome: ItemStreamOutcome::finished_with(value, Vec::new()),
         cmd_blocks_processed: vec![],
         cmd_blocks_not_processed: vec![],
         errors: IndexMap::new(),

--- a/workspace_tests/src/cmd_model/item_stream_outcome.rs
+++ b/workspace_tests/src/cmd_model/item_stream_outcome.rs
@@ -1,0 +1,31 @@
+use peace::{
+    cfg::{item_id, ItemId},
+    cmd_model::ItemStreamOutcome,
+};
+
+#[test]
+fn replace() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    let (item_stream_outcome, n) = item_stream_outcome.replace(2u32);
+
+    assert_eq!(1u16, n);
+    assert_eq!(
+        ItemStreamOutcome::finished_with(2u32, vec![item_id!("mock")]),
+        item_stream_outcome
+    );
+}
+
+#[test]
+fn replace_with() {
+    let item_stream_outcome =
+        ItemStreamOutcome::finished_with((1u16, "value_to_extract"), vec![item_id!("mock")]);
+
+    let (item_stream_outcome, value) = item_stream_outcome.replace_with(|(n, value)| (n, value));
+
+    assert_eq!("value_to_extract", value);
+    assert_eq!(
+        ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]),
+        item_stream_outcome
+    );
+}

--- a/workspace_tests/src/cmd_model/item_stream_outcome.rs
+++ b/workspace_tests/src/cmd_model/item_stream_outcome.rs
@@ -1,7 +1,20 @@
 use peace::{
     cfg::{item_id, ItemId},
     cmd_model::ItemStreamOutcome,
+    rt_model::fn_graph::StreamOutcomeState,
 };
+
+#[test]
+fn map() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    let item_stream_outcome = item_stream_outcome.map(|n| n + 1);
+
+    assert_eq!(
+        ItemStreamOutcome::finished_with(2u16, vec![item_id!("mock")]),
+        item_stream_outcome
+    );
+}
 
 #[test]
 fn replace() {
@@ -28,4 +41,69 @@ fn replace_with() {
         ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]),
         item_stream_outcome
     );
+}
+
+#[test]
+fn into_value() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    let n = item_stream_outcome.into_value();
+
+    assert_eq!(1u16, n);
+}
+
+#[test]
+fn value() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    let n = item_stream_outcome.value();
+
+    assert_eq!(1u16, *n);
+}
+
+#[test]
+fn value_mut() {
+    let mut item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    *item_stream_outcome.value_mut() += 1;
+
+    assert_eq!(2u16, *item_stream_outcome.value());
+}
+
+#[test]
+fn state() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    assert_eq!(StreamOutcomeState::Finished, item_stream_outcome.state());
+}
+
+#[test]
+fn item_ids_processed() {
+    let item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+
+    assert_eq!(
+        &[item_id!("mock")],
+        item_stream_outcome.item_ids_processed()
+    );
+}
+
+#[test]
+fn item_ids_not_processed() {
+    let mut item_stream_outcome = ItemStreamOutcome::finished_with(1u16, vec![item_id!("mock")]);
+    item_stream_outcome.item_ids_not_processed = vec![item_id!("mock_1")];
+
+    assert_eq!(
+        &[item_id!("mock_1")],
+        item_stream_outcome.item_ids_not_processed()
+    );
+}
+
+#[test]
+fn default() {
+    let item_stream_outcome = ItemStreamOutcome::<u16>::default();
+
+    assert_eq!(0u16, *item_stream_outcome.value());
+    assert_eq!(StreamOutcomeState::NotStarted, item_stream_outcome.state());
+    assert!(item_stream_outcome.item_ids_processed().is_empty());
+    assert!(item_stream_outcome.item_ids_not_processed().is_empty());
 }

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -798,7 +798,7 @@ async fn states_current_not_serialized_on_states_clean_insert_cmd_block_fail()
     };
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -806,7 +806,7 @@ async fn states_current_not_serialized_on_states_clean_insert_cmd_block_fail()
     else {
         panic!("Expected `CleanCmd::exec` to complete with item error.");
     };
-    let states_cleaned = stream_outcome.value();
+    let states_cleaned = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
@@ -921,7 +921,7 @@ async fn states_current_not_serialized_on_states_discover_cmd_block_fail()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -929,7 +929,7 @@ async fn states_current_not_serialized_on_states_discover_cmd_block_fail()
     else {
         panic!("Expected `CleanCmd::exec` to complete with item error.");
     };
-    let states_cleaned = stream_outcome.value();
+    let states_cleaned = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0u8, 1, 2, 3, 4, 5, 6, 7])).as_ref(),

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1294,7 +1294,6 @@ async fn exec_returns_item_error_when_item_apply_returns_error()
     Ok(())
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[tokio::test]
 async fn states_current_not_serialized_on_states_current_read_cmd_block_interrupt()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -1381,7 +1380,6 @@ async fn states_current_not_serialized_on_states_current_read_cmd_block_interrup
     Ok(())
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[tokio::test]
 async fn states_current_not_serialized_on_states_goal_read_cmd_block_interrupt()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -1593,7 +1591,6 @@ async fn states_current_not_serialized_on_states_discover_cmd_block_fail()
     Ok(())
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
 #[tokio::test]
 async fn states_current_not_serialized_on_apply_state_sync_check_cmd_block_interrupt()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -1690,6 +1687,143 @@ async fn states_current_not_serialized_on_apply_state_sync_check_cmd_block_inter
     assert_eq!(states_current_content, states_current_content_after_exec);
     let states_goal_content_after_exec = tokio::fs::read_to_string(&states_goal_file).await?;
     assert_eq!(states_goal_content, states_goal_content_after_exec);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn states_current_is_serialized_on_apply_exec_cmd_block_interrupt()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tempdir = tempfile::tempdir()?;
+    let workspace = Workspace::new(
+        app_name!(),
+        WorkspaceSpec::Path(tempdir.path().to_path_buf()),
+    )?;
+    let graph = {
+        let mut graph_builder = ItemGraphBuilder::<PeaceTestError>::new();
+        let vec_copy_id = graph_builder.add_fn(VecCopyItem::default().into());
+        let mock_id = graph_builder.add_fn(MockItem::<()>::default().into());
+        graph_builder.add_edge(vec_copy_id, mock_id)?;
+        graph_builder.build()
+    };
+    let flow = Flow::new(FlowId::new(crate::fn_name_short!())?, graph);
+    let mut output = NoOpOutput;
+
+    let (interrupt_tx, interrupt_rx) = mpsc::channel::<InterruptSignal>(16);
+
+    let mut cmd_ctx = CmdCtx::builder_single_profile_single_flow(&mut output, &workspace)
+        .with_interruptibility(Interruptibility::new(
+            interrupt_rx.into(),
+            InterruptStrategy::PollNextN(9),
+        ))
+        .with_profile(profile!("test_profile"))
+        .with_flow(&flow)
+        .with_item_params::<VecCopyItem>(
+            VecCopyItem::ID_DEFAULT.clone(),
+            VecA(vec![0, 1, 2, 3, 4, 5, 6, 7]).into(),
+        )
+        .with_item_params::<MockItem<()>>(MockItem::<()>::ID_DEFAULT.clone(), MockSrc(1).into())
+        .await?;
+
+    // Note: Write custom states current and states goal files to disk.
+    let flow_dir = cmd_ctx.flow_dir();
+    let states_current_content = "\
+        vec_copy: []\n\
+        mock: 0\n\
+    ";
+    let states_goal_content = "\
+        vec_copy: [0, 1, 2, 3, 4, 5, 6, 7]\n\
+        mock: 1\n\
+    ";
+    let states_current_file = StatesCurrentFile::from(flow_dir);
+    tokio::fs::write(&states_current_file, states_current_content.as_bytes()).await?;
+    let states_goal_file = StatesGoalFile::from(flow_dir);
+    tokio::fs::write(&states_goal_file, states_goal_content.as_bytes()).await?;
+
+    interrupt_tx.send(InterruptSignal).await?;
+    let cmd_outcome = EnsureCmd::exec_with(&mut cmd_ctx, ApplyStoredStateSync::Both).await?;
+    let CmdOutcome::BlockInterrupted {
+        item_stream_outcome,
+        cmd_blocks_processed,
+        cmd_blocks_not_processed,
+    } = cmd_outcome
+    else {
+        panic!(
+            "Expected `EnsureCmd::exec_with` to complete with interruption,\n\
+            but was:\n\
+            \n\
+            ```ron\n\
+            {cmd_outcome:#?}\n\
+            ```\n\
+            "
+        );
+    };
+    let states_ensured = item_stream_outcome.value();
+
+    // Early interruption returns empty `states_ensured`.
+    assert_eq!(2, states_ensured.len());
+    assert_eq!(
+        Some(VecCopyState::from(vec![0u8, 1, 2, 3, 4, 5, 6, 7])).as_ref(),
+        states_ensured.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT)
+    );
+    assert_eq!(
+        Some(MockState(0)).as_ref(),
+        states_ensured.get::<MockState, _>(MockItem::<()>::ID_DEFAULT)
+    );
+    assert_eq!(
+        &[
+            "StatesCurrentReadCmdBlock",
+            "StatesGoalReadCmdBlock",
+            "StatesDiscoverCmdBlock",
+            "ApplyStateSyncCheckCmdBlock",
+        ],
+        cmd_blocks_processed
+            .iter()
+            .map(CmdBlockDesc::cmd_block_name)
+            .collect::<Vec<_>>()
+            .as_slice()
+    );
+    assert_eq!(
+        &["ApplyExecCmdBlock",],
+        cmd_blocks_not_processed
+            .iter()
+            .map(CmdBlockDesc::cmd_block_name)
+            .collect::<Vec<_>>()
+            .as_slice()
+    );
+
+    // Note: Expect interruption to be between `vec_copy` and `mock` items.
+    let states_current_content_expected = r#"vec_copy:
+- 0
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+mock: 0
+"#;
+    // Note: states_goal_file is re-serialized, because we may have generated
+    // information for earlier items that are used for later items' goal state.
+    let states_goal_content_expected = r#"vec_copy:
+- 0
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+mock: 1
+"#;
+    let states_current_content_after_exec = tokio::fs::read_to_string(&states_current_file).await?;
+    assert_eq!(
+        states_current_content_expected,
+        states_current_content_after_exec
+    );
+    let states_goal_content_after_exec = tokio::fs::read_to_string(&states_goal_file).await?;
+    assert_eq!(states_goal_content_expected, states_goal_content_after_exec);
 
     Ok(())
 }

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -819,7 +819,7 @@ async fn exec_dry_returns_item_error_when_item_discover_current_returns_error()
 
     // Dry ensure states.
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -827,7 +827,7 @@ async fn exec_dry_returns_item_error_when_item_discover_current_returns_error()
     else {
         panic!("Expected `EnsureCmd::exec_dry_with` to complete with item error.");
     };
-    let states_ensured_dry = stream_outcome.value();
+    let states_ensured_dry = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
@@ -927,7 +927,7 @@ async fn exec_dry_returns_item_error_when_item_discover_goal_returns_error()
 
     // Dry ensure states.
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -935,7 +935,7 @@ async fn exec_dry_returns_item_error_when_item_discover_goal_returns_error()
     else {
         panic!("Expected `EnsureCmd::exec_dry_with` to complete with item error.");
     };
-    let states_ensured_dry = stream_outcome.value();
+    let states_ensured_dry = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
@@ -1035,7 +1035,7 @@ async fn exec_dry_returns_item_error_when_item_apply_check_returns_error()
 
     // Dry ensure states.
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -1043,7 +1043,7 @@ async fn exec_dry_returns_item_error_when_item_apply_check_returns_error()
     else {
         panic!("Expected `EnsureCmd::exec_dry_with` to complete with item error.");
     };
-    let states_ensured_dry = stream_outcome.value();
+    let states_ensured_dry = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
@@ -1143,7 +1143,7 @@ async fn exec_dry_returns_item_error_when_item_apply_dry_returns_error()
 
     // Dry ensure states.
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -1151,7 +1151,7 @@ async fn exec_dry_returns_item_error_when_item_apply_dry_returns_error()
     else {
         panic!("Expected `EnsureCmd::exec_dry_with` to complete with item error.");
     };
-    let states_ensured_dry = stream_outcome.value();
+    let states_ensured_dry = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
@@ -1251,7 +1251,7 @@ async fn exec_returns_item_error_when_item_apply_returns_error()
 
     // Ensure states again.
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -1259,7 +1259,7 @@ async fn exec_returns_item_error_when_item_apply_returns_error()
     else {
         panic!("Expected `EnsureCmd::exec_with` to complete with item error.");
     };
-    let states_ensured_again = stream_outcome.value();
+    let states_ensured_again = item_stream_outcome.value();
 
     assert_eq!(
         Some(VecCopyState::from(vec![0, 1, 2, 3])).as_ref(),
@@ -1531,7 +1531,7 @@ async fn states_current_not_serialized_on_states_discover_cmd_block_fail()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed,
         cmd_blocks_not_processed,
         errors,
@@ -1539,7 +1539,7 @@ async fn states_current_not_serialized_on_states_discover_cmd_block_fail()
     else {
         panic!("Expected `EnsureCmd::exec` to complete with item error.");
     };
-    let states_ensured = stream_outcome.value();
+    let states_ensured = item_stream_outcome.value();
 
     assert_eq!(
         None,

--- a/workspace_tests/src/rt/cmds/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_discover_cmd.rs
@@ -270,7 +270,7 @@ async fn current_returns_error_when_try_state_current_returns_error()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -278,7 +278,7 @@ async fn current_returns_error_when_try_state_current_returns_error()
     else {
         panic!("Expected `StatesDiscoverCmd::current` to complete with item error.");
     };
-    let states_current = stream_outcome.value();
+    let states_current = item_stream_outcome.value();
 
     let vec_copy_state = states_current.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT);
     let CmdOutcome::Complete {
@@ -346,7 +346,7 @@ async fn goal_returns_error_when_try_state_goal_returns_error()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -354,7 +354,7 @@ async fn goal_returns_error_when_try_state_goal_returns_error()
     else {
         panic!("Expected `StatesDiscoverCmd::goal` to complete with item error.");
     };
-    let states_goal = stream_outcome.value();
+    let states_goal = item_stream_outcome.value();
 
     let vec_copy_state = states_goal.get::<VecCopyState, _>(VecCopyItem::ID_DEFAULT);
     let CmdOutcome::Complete {
@@ -425,7 +425,7 @@ async fn current_and_goal_returns_error_when_try_state_current_returns_error()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -433,7 +433,7 @@ async fn current_and_goal_returns_error_when_try_state_current_returns_error()
     else {
         panic!("Expected `StatesDiscoverCmd::current_and_goal` to complete with item error.");
     };
-    let (states_current, states_goal) = stream_outcome.value();
+    let (states_current, states_goal) = item_stream_outcome.value();
 
     // States current assertions
     let CmdOutcome::Complete {
@@ -529,7 +529,7 @@ async fn current_and_goal_returns_error_when_try_state_goal_returns_error()
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -537,7 +537,7 @@ async fn current_and_goal_returns_error_when_try_state_goal_returns_error()
     else {
         panic!("Expected `StatesDiscoverCmd::current_and_goal` to complete with item error.");
     };
-    let (states_current, states_goal) = stream_outcome.value();
+    let (states_current, states_goal) = item_stream_outcome.value();
 
     // States current assertions
     let CmdOutcome::Complete {
@@ -635,7 +635,7 @@ async fn current_and_goal_returns_current_error_when_both_try_state_current_and_
         .await?;
 
     let CmdOutcome::ItemError {
-        stream_outcome,
+        item_stream_outcome,
         cmd_blocks_processed: _,
         cmd_blocks_not_processed: _,
         errors,
@@ -643,7 +643,7 @@ async fn current_and_goal_returns_current_error_when_both_try_state_current_and_
     else {
         panic!("Expected `StatesDiscoverCmd::current_and_goal` to complete with item error.");
     };
-    let (states_current, states_goal) = stream_outcome.value();
+    let (states_current, states_goal) = item_stream_outcome.value();
 
     // States current assertions
     let CmdOutcome::Complete {


### PR DESCRIPTION
Closes #164.