### PR TITLE
Add `peace::cfg::` prefix to `id_newtype` macro usages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 ## unreleased
 
 * Provide more accurate feedback about interruption on CLI. ([#172], [#173])
+* Remove requirement to import `peace::cfg::AppName` when using `app_name!("..")` macro. ([#157], [#176])
+* Remove requirement to import `peace::cfg::FlowId` when using `flow_id!("..")` macro. ([#157], [#176])
+* Remove requirement to import `peace::cfg::ItemId` when using `item_id!("..")` macro. ([#157], [#176])
+* Remove requirement to import `peace::cfg::Profile` when using `profile!("..")` macro. ([#157], [#176])
 
 
 [#172]: https://github.com/azriel91/peace/issues/172
 [#173]: https://github.com/azriel91/peace/pull/173
+[#157]: https://github.com/azriel91/peace/issues/157
+[#176]: https://github.com/azriel91/peace/pull/176
 
 
 ## 0.0.12 (2023-12-30)

--- a/crate/static_check_macros/src/lib.rs
+++ b/crate/static_check_macros/src/lib.rs
@@ -182,7 +182,7 @@ fn ensure_valid_id(
     if let Some(proposed_id) = proposed_id {
         if is_valid_id(proposed_id) {
             let ty_name = Ident::new(ty_name, Span::call_site());
-            quote!( #ty_name ::new_unchecked( #proposed_id ))
+            quote!( peace::cfg:: #ty_name ::new_unchecked( #proposed_id ))
         } else {
             let message = format!(
                 "\"{proposed_id}\" is not a valid `{ty_name}`.\n\

--- a/crate/static_check_macros/src/lib.rs
+++ b/crate/static_check_macros/src/lib.rs
@@ -232,7 +232,10 @@ mod tests {
             None,
         );
 
-        assert_eq!(r#"Ty :: new_unchecked ("_")"#, tokens.to_string());
+        assert_eq!(
+            r#"peace :: cfg :: Ty :: new_unchecked ("_")"#,
+            tokens.to_string()
+        );
     }
 
     #[test]
@@ -242,7 +245,10 @@ mod tests {
             "Ty",
             None,
         );
-        assert_eq!(r#"Ty :: new_unchecked ("a")"#, tokens.to_string());
+        assert_eq!(
+            r#"peace :: cfg :: Ty :: new_unchecked ("a")"#,
+            tokens.to_string()
+        );
 
         let tokens = ensure_valid_id(
             &LitStrMaybe(Some(LitStr::new("A", Span::call_site()))),
@@ -250,7 +256,10 @@ mod tests {
             None,
         );
 
-        assert_eq!(r#"Ty :: new_unchecked ("A")"#, tokens.to_string());
+        assert_eq!(
+            r#"peace :: cfg :: Ty :: new_unchecked ("A")"#,
+            tokens.to_string()
+        );
     }
 
     #[test]

--- a/examples/download/src/lib.rs
+++ b/examples/download/src/lib.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, item_id, AppName, FlowId, ItemId, Profile},
+    cfg::{app_name, item_id, FlowId, ItemId, Profile},
     cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlow},
     cmd_model::CmdOutcome,
     resources::resources::ts::SetUp,

--- a/examples/download/src/main.rs
+++ b/examples/download/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use peace::{
-    cfg::{flow_id, profile, FlowId, Profile},
+    cfg::{flow_id, profile},
     rt_model::{output::CliOutput, WorkspaceSpec},
 };
 use peace_items::file_download::FileDownloadParams;

--- a/examples/download/src/wasm.rs
+++ b/examples/download/src/wasm.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{flow_id, profile, FlowId, Profile},
+    cfg::{flow_id, profile},
     rt_model::{InMemoryTextOutput, WorkspaceSpec},
 };
 use peace_items::file_download::{FileDownloadParams, StorageForm};

--- a/examples/envman/src/cmds/app_upload_cmd.rs
+++ b/examples/envman/src/cmds/app_upload_cmd.rs
@@ -1,6 +1,6 @@
 use futures::future::LocalBoxFuture;
 use peace::{
-    cfg::{app_name, item_id, AppName, ItemId, Profile},
+    cfg::{app_name, item_id, Profile},
     cmd::{
         ctx::CmdCtx,
         scopes::{

--- a/examples/envman/src/cmds/common.rs
+++ b/examples/envman/src/cmds/common.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, AppName},
+    cfg::{app_name},
     cmd::ctx::CmdCtx,
     rt_model::{output::OutputWrite, Workspace, WorkspaceSpec},
 };

--- a/examples/envman/src/cmds/common.rs
+++ b/examples/envman/src/cmds/common.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name},
+    cfg::app_name,
     cmd::ctx::CmdCtx,
     rt_model::{output::OutputWrite, Workspace, WorkspaceSpec},
 };

--- a/examples/envman/src/cmds/env_cmd.rs
+++ b/examples/envman/src/cmds/env_cmd.rs
@@ -1,6 +1,6 @@
 use futures::future::LocalBoxFuture;
 use peace::{
-    cfg::{app_name, item_id, state::Generated, AppName, ItemId, Profile},
+    cfg::{app_name, item_id, state::Generated, Profile},
     cmd::{
         ctx::CmdCtx,
         scopes::{

--- a/examples/envman/src/cmds/profile_init_cmd.rs
+++ b/examples/envman/src/cmds/profile_init_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, item_id, AppName, ItemId, Profile},
+    cfg::{app_name, item_id, Profile},
     cmd::{
         ctx::CmdCtx,
         scopes::{

--- a/examples/envman/src/cmds/profile_list_cmd.rs
+++ b/examples/envman/src/cmds/profile_list_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name},
+    cfg::app_name,
     cmd::{ctx::CmdCtx, scopes::MultiProfileNoFlowView},
     fmt::presentable::{Heading, HeadingLevel},
     rt_model::{output::OutputWrite, Workspace, WorkspaceSpec},

--- a/examples/envman/src/cmds/profile_list_cmd.rs
+++ b/examples/envman/src/cmds/profile_list_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, AppName},
+    cfg::{app_name},
     cmd::{ctx::CmdCtx, scopes::MultiProfileNoFlowView},
     fmt::presentable::{Heading, HeadingLevel},
     rt_model::{output::OutputWrite, Workspace, WorkspaceSpec},

--- a/examples/envman/src/cmds/profile_show_cmd.rs
+++ b/examples/envman/src/cmds/profile_show_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, AppName, Profile},
+    cfg::{app_name, Profile},
     cmd::{ctx::CmdCtx, scopes::SingleProfileNoFlowView},
     fmt::presentln,
     rt_model::{output::OutputWrite, Workspace, WorkspaceSpec},

--- a/examples/envman/src/cmds/profile_switch_cmd.rs
+++ b/examples/envman/src/cmds/profile_switch_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name},
+    cfg::app_name,
     cmd::{ctx::CmdCtx, scopes::MultiProfileNoFlowView},
     rt_model::output::OutputWrite,
 };

--- a/examples/envman/src/cmds/profile_switch_cmd.rs
+++ b/examples/envman/src/cmds/profile_switch_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, AppName},
+    cfg::{app_name},
     cmd::{ctx::CmdCtx, scopes::MultiProfileNoFlowView},
     rt_model::output::OutputWrite,
 };

--- a/examples/envman/src/flows/app_upload_flow.rs
+++ b/examples/envman/src/flows/app_upload_flow.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use peace::{
-    cfg::{app_name, flow_id, item_id, AppName, FlowId, ItemId, Profile},
+    cfg::{app_name, flow_id, item_id, Profile},
     params::{Params, ParamsSpec},
     rt_model::{Flow, ItemGraphBuilder},
 };

--- a/examples/envman/src/flows/env_deploy_flow.rs
+++ b/examples/envman/src/flows/env_deploy_flow.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use peace::{
-    cfg::{app_name, flow_id, item_id, state::Generated, AppName, FlowId, ItemId, Profile},
+    cfg::{app_name, flow_id, item_id, state::Generated, Profile},
     params::{Params, ParamsSpec},
     rt_model::{Flow, ItemGraphBuilder},
 };

--- a/workspace_tests/src/cfg/progress/progress_sender.rs
+++ b/workspace_tests/src/cfg/progress/progress_sender.rs
@@ -5,7 +5,6 @@ use peace::{
             CmdProgressUpdate, ProgressDelta, ProgressMsgUpdate, ProgressSender,
             ProgressUpdateAndId,
         },
-        ItemId,
     },
     rt_model::ProgressUpdate,
 };

--- a/workspace_tests/src/cfg/progress/progress_update_and_id.rs
+++ b/workspace_tests/src/cfg/progress/progress_update_and_id.rs
@@ -4,7 +4,6 @@ use peace::cfg::{
         ProgressComplete, ProgressDelta, ProgressLimit, ProgressMsgUpdate, ProgressUpdate,
         ProgressUpdateAndId,
     },
-    ItemId,
 };
 
 #[test]

--- a/workspace_tests/src/cmd/ctx/cmd_ctx.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, flow_id, profile, AppName, FlowId, Profile},
+    cfg::{app_name, flow_id, profile, AppName},
     cmd::ctx::CmdCtxBuilder,
     rt_model::{Flow, ItemGraphBuilder, Workspace},
 };

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/multi_profile_no_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/multi_profile_no_flow_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use peace::{
-    cfg::{app_name, profile, AppName, Profile, ProfileInvalidFmt},
+    cfg::{app_name, profile, Profile, ProfileInvalidFmt},
     cmd::ctx::CmdCtx,
     resources::paths::{ProfileDir, ProfileHistoryDir},
     rt_model::{params::ParamsTypeRegs, Error as PeaceRtError, NativeError},

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/multi_profile_single_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/multi_profile_single_flow_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use peace::{
-    cfg::{app_name, flow_id, profile, AppName, FlowId, Profile},
+    cfg::{app_name, flow_id, profile},
     cmd::ctx::CmdCtx,
     resources::paths::{FlowDir, ProfileDir, ProfileHistoryDir},
     rt_model::{params::ParamsTypeRegs, Flow, ItemGraphBuilder, ParamsSpecsTypeReg, StatesTypeReg},

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/no_profile_no_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/no_profile_no_flow_builder.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, Profile},
+    cfg::{app_name, profile},
     cmd::ctx::CmdCtx,
 };
 

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_no_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_no_flow_builder.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, Profile},
+    cfg::{app_name, profile},
     cmd::ctx::CmdCtx,
     resources::paths::{ProfileDir, ProfileHistoryDir},
 };

--- a/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
+++ b/workspace_tests/src/cmd/ctx/cmd_ctx_builder/single_profile_single_flow_builder.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, flow_id, item_id, profile, AppName, FlowId, Item, ItemId, Profile},
+    cfg::{app_name, flow_id, item_id, profile, Item, Profile},
     cmd::ctx::CmdCtx,
     params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
     resources::{

--- a/workspace_tests/src/cmd_model/cmd_block_outcome.rs
+++ b/workspace_tests/src/cmd_model/cmd_block_outcome.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     cmd_model::{CmdBlockOutcome, StreamOutcomeAndErrors, ValueAndStreamOutcome},
     rt_model::{fn_graph::StreamOutcome, IndexMap},
 };

--- a/workspace_tests/src/cmd_model/cmd_block_outcome.rs
+++ b/workspace_tests/src/cmd_model/cmd_block_outcome.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     cmd_model::{CmdBlockOutcome, StreamOutcomeAndErrors, ValueAndStreamOutcome},
     rt_model::{fn_graph::StreamOutcome, IndexMap},
 };

--- a/workspace_tests/src/cmd_model/item_stream_outcome.rs
+++ b/workspace_tests/src/cmd_model/item_stream_outcome.rs
@@ -1,8 +1,4 @@
-use peace::{
-    cfg::{item_id},
-    cmd_model::ItemStreamOutcome,
-    rt_model::fn_graph::StreamOutcomeState,
-};
+use peace::{cfg::item_id, cmd_model::ItemStreamOutcome, rt_model::fn_graph::StreamOutcomeState};
 
 #[test]
 fn map() {

--- a/workspace_tests/src/cmd_model/item_stream_outcome.rs
+++ b/workspace_tests/src/cmd_model/item_stream_outcome.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     cmd_model::ItemStreamOutcome,
     rt_model::fn_graph::StreamOutcomeState,
 };

--- a/workspace_tests/src/cmd_rt/cmd_execution.rs
+++ b/workspace_tests/src/cmd_rt/cmd_execution.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     cmd_rt::{CmdBlockRt, CmdBlockWrapper, CmdExecution},

--- a/workspace_tests/src/cmd_rt/cmd_execution/cmd_execution_error_builder.rs
+++ b/workspace_tests/src/cmd_rt/cmd_execution/cmd_execution_error_builder.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdExecutionError,
     cmd_rt::{CmdBlockWrapper, CmdExecution},

--- a/workspace_tests/src/items/sh_cmd_item.rs
+++ b/workspace_tests/src/items/sh_cmd_item.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, item_id, profile, AppName, FlowId, ItemId, Profile, State},
+    cfg::{app_name, item_id, profile, FlowId, ItemId, State},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     data::marker::Clean,

--- a/workspace_tests/src/items/tar_x_item.rs
+++ b/workspace_tests/src/items/tar_x_item.rs
@@ -1,7 +1,7 @@
 use std::{io::Cursor, path::PathBuf};
 
 use peace::{
-    cfg::{app_name, item_id, profile, AppName, ApplyCheck, FlowId, Item, ItemId, Profile},
+    cfg::{app_name, item_id, profile, ApplyCheck, FlowId, Item, ItemId, Profile},
     cmd::{ctx::CmdCtx, scopes::SingleProfileSingleFlowView},
     cmd_model::CmdOutcome,
     data::Data,

--- a/workspace_tests/src/params/derive.rs
+++ b/workspace_tests/src/params/derive.rs
@@ -70,7 +70,7 @@ mod struct_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -269,7 +269,7 @@ mod struct_with_type_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -489,7 +489,7 @@ mod tuple_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -665,7 +665,7 @@ mod tuple_with_type_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -866,7 +866,7 @@ mod enum_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -1499,7 +1499,7 @@ mod struct_recursive_value {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id},
+        cfg::item_id,
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };

--- a/workspace_tests/src/params/derive.rs
+++ b/workspace_tests/src/params/derive.rs
@@ -70,7 +70,7 @@ mod struct_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -269,7 +269,7 @@ mod struct_with_type_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -489,7 +489,7 @@ mod tuple_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -665,7 +665,7 @@ mod tuple_with_type_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -866,7 +866,7 @@ mod enum_params {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };
@@ -1499,7 +1499,7 @@ mod struct_recursive_value {
     use serde::{Deserialize, Serialize};
 
     use peace::{
-        cfg::{item_id, ItemId},
+        cfg::{item_id},
         params::{Params, ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec},
         resources::{resources::ts::SetUp, Resources},
     };

--- a/workspace_tests/src/params/mapping_fn_impl.rs
+++ b/workspace_tests/src/params/mapping_fn_impl.rs
@@ -41,7 +41,7 @@ macro_rules! mapping_tests {
         mod $module_name {
             use peace::{
                 data::marker::$value_resolution_mode,
-                cfg::{item_id, ItemId},
+                cfg::{item_id},
                 params::{
                     MappingFn, MappingFnImpl, ParamsResolveError,
                     ValueResolutionCtx, ValueResolutionMode,

--- a/workspace_tests/src/params/params_spec.rs
+++ b/workspace_tests/src/params/params_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     params::{
         AnySpecRt, AnySpecRtBoxed, FieldNameAndType, FieldWiseSpecRt, Params, ParamsResolveError,
         ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec, ValueSpecRt,

--- a/workspace_tests/src/params/params_spec.rs
+++ b/workspace_tests/src/params/params_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     params::{
         AnySpecRt, AnySpecRtBoxed, FieldNameAndType, FieldWiseSpecRt, Params, ParamsResolveError,
         ParamsSpec, ValueResolutionCtx, ValueResolutionMode, ValueSpec, ValueSpecRt,

--- a/workspace_tests/src/params/params_spec_fieldless.rs
+++ b/workspace_tests/src/params/params_spec_fieldless.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     params::{
         AnySpecRt, AnySpecRtBoxed, ParamsFieldless, ParamsResolveError, ParamsSpecFieldless,
         ValueResolutionCtx, ValueResolutionMode, ValueSpecRt,

--- a/workspace_tests/src/params/params_spec_fieldless.rs
+++ b/workspace_tests/src/params/params_spec_fieldless.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     params::{
         AnySpecRt, AnySpecRtBoxed, ParamsFieldless, ParamsResolveError, ParamsSpecFieldless,
         ValueResolutionCtx, ValueResolutionMode, ValueSpecRt,

--- a/workspace_tests/src/params/params_specs.rs
+++ b/workspace_tests/src/params/params_specs.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     params::{ParamsSpec, ParamsSpecs},
 };
 

--- a/workspace_tests/src/params/params_specs.rs
+++ b/workspace_tests/src/params/params_specs.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     params::{ParamsSpec, ParamsSpecs},
 };
 

--- a/workspace_tests/src/params/value_resolution_ctx.rs
+++ b/workspace_tests/src/params/value_resolution_ctx.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     params::{FieldNameAndType, ValueResolutionCtx, ValueResolutionMode},
 };
 

--- a/workspace_tests/src/params/value_resolution_ctx.rs
+++ b/workspace_tests/src/params/value_resolution_ctx.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     params::{FieldNameAndType, ValueResolutionCtx, ValueResolutionMode},
 };
 

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     params::{
         AnySpecRt, AnySpecRtBoxed, ParamsResolveError, ValueResolutionCtx, ValueResolutionMode,
         ValueSpec, ValueSpecRt,

--- a/workspace_tests/src/params/value_spec.rs
+++ b/workspace_tests/src/params/value_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     params::{
         AnySpecRt, AnySpecRtBoxed, ParamsResolveError, ValueResolutionCtx, ValueResolutionMode,
         ValueSpec, ValueSpecRt,

--- a/workspace_tests/src/resources/dir/profile_dir.rs
+++ b/workspace_tests/src/resources/dir/profile_dir.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsStr, path::Path};
 
 use peace::{
-    cfg::{app_name, profile, AppName, Profile},
+    cfg::{app_name, profile},
     resources::paths::{PeaceAppDir, PeaceDir, ProfileDir},
 };
 

--- a/workspace_tests/src/resources/dir/profile_history_dir.rs
+++ b/workspace_tests/src/resources/dir/profile_history_dir.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsStr, path::Path};
 
 use peace::{
-    cfg::{app_name, profile, AppName, Profile},
+    cfg::{app_name, profile},
     resources::paths::{PeaceAppDir, PeaceDir, ProfileDir, ProfileHistoryDir},
 };
 

--- a/workspace_tests/src/resources/dir/states_current_file.rs
+++ b/workspace_tests/src/resources/dir/states_current_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name, flow_id, profile, AppName, FlowId, Profile},
+    cfg::{app_name, flow_id, profile},
     resources::paths::{FlowDir, PeaceAppDir, PeaceDir, ProfileDir, StatesCurrentFile},
 };
 

--- a/workspace_tests/src/resources/dir/states_goal_file.rs
+++ b/workspace_tests/src/resources/dir/states_goal_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name, flow_id, profile, AppName, FlowId, Profile},
+    cfg::{app_name, flow_id, profile},
     resources::paths::{FlowDir, PeaceAppDir, PeaceDir, ProfileDir, StatesGoalFile},
 };
 

--- a/workspace_tests/src/resources/internal/flow_params_file.rs
+++ b/workspace_tests/src/resources/internal/flow_params_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name, flow_id, profile, AppName, FlowId, Profile},
+    cfg::{app_name, flow_id, profile},
     resources::{
         internal::FlowParamsFile,
         paths::{FlowDir, PeaceAppDir, PeaceDir, ProfileDir},

--- a/workspace_tests/src/resources/internal/profile_params_file.rs
+++ b/workspace_tests/src/resources/internal/profile_params_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name, profile, AppName, Profile},
+    cfg::{app_name, profile},
     resources::{
         internal::ProfileParamsFile,
         paths::{PeaceAppDir, PeaceDir, ProfileDir},

--- a/workspace_tests/src/resources/internal/state_diffs_mut.rs
+++ b/workspace_tests/src/resources/internal/state_diffs_mut.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     resources::{internal::StateDiffsMut, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/internal/state_diffs_mut.rs
+++ b/workspace_tests/src/resources/internal/state_diffs_mut.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     resources::{internal::StateDiffsMut, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/internal/states_mut.rs
+++ b/workspace_tests/src/resources/internal/states_mut.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     resources::{internal::StatesMut, states::ts::Current, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/internal/states_mut.rs
+++ b/workspace_tests/src/resources/internal/states_mut.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     resources::{internal::StatesMut, states::ts::Current, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/internal/workspace_params_file.rs
+++ b/workspace_tests/src/resources/internal/workspace_params_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name, AppName},
+    cfg::{app_name},
     resources::{
         internal::WorkspaceParamsFile,
         paths::{PeaceAppDir, PeaceDir},

--- a/workspace_tests/src/resources/internal/workspace_params_file.rs
+++ b/workspace_tests/src/resources/internal/workspace_params_file.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use peace::{
-    cfg::{app_name},
+    cfg::app_name,
     resources::{
         internal::WorkspaceParamsFile,
         paths::{PeaceAppDir, PeaceDir},

--- a/workspace_tests/src/resources/state_diffs.rs
+++ b/workspace_tests/src/resources/state_diffs.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     resources::{internal::StateDiffsMut, states::StateDiffs, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/state_diffs.rs
+++ b/workspace_tests/src/resources/state_diffs.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     resources::{internal::StateDiffsMut, states::StateDiffs, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/states.rs
+++ b/workspace_tests/src/resources/states.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     resources::{internal::StatesMut, states::StatesCurrent, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/resources/states.rs
+++ b/workspace_tests/src/resources/states.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     resources::{internal::StatesMut, states::StatesCurrent, type_reg::untagged::TypeMap},
 };
 

--- a/workspace_tests/src/rt/cmds/clean_cmd.rs
+++ b/workspace_tests/src/rt/cmds/clean_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     resources::type_reg::untagged::BoxDataTypeDowncast,

--- a/workspace_tests/src/rt/cmds/diff_cmd.rs
+++ b/workspace_tests/src/rt/cmds/diff_cmd.rs
@@ -1,6 +1,6 @@
 use diff::{VecDiff, VecDiffType};
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     params::ParamsSpec,

--- a/workspace_tests/src/rt/cmds/diff_cmd/diff_info_spec.rs
+++ b/workspace_tests/src/rt/cmds/diff_cmd/diff_info_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{profile, Profile},
+    cfg::{profile},
     rt::cmds::{DiffInfoSpec, DiffStateSpec},
 };
 

--- a/workspace_tests/src/rt/cmds/diff_cmd/diff_info_spec.rs
+++ b/workspace_tests/src/rt/cmds/diff_cmd/diff_info_spec.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{profile},
+    cfg::profile,
     rt::cmds::{DiffInfoSpec, DiffStateSpec},
 };
 

--- a/workspace_tests/src/rt/cmds/ensure_cmd.rs
+++ b/workspace_tests/src/rt/cmds/ensure_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::{
         ctx::CmdCtx,
         interruptible::{InterruptSignal, InterruptStrategy, Interruptibility},

--- a/workspace_tests/src/rt/cmds/states_current_read_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_current_read_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     rt::cmds::{StatesCurrentReadCmd, StatesDiscoverCmd},

--- a/workspace_tests/src/rt/cmds/states_current_stored_display_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_current_stored_display_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     rt::cmds::{StatesCurrentStoredDisplayCmd, StatesDiscoverCmd},

--- a/workspace_tests/src/rt/cmds/states_discover_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_discover_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, ItemId, Profile},
+    cfg::{app_name, profile, FlowId, ItemId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     resources::{

--- a/workspace_tests/src/rt/cmds/states_goal_display_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_goal_display_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     rt::cmds::{StatesDiscoverCmd, StatesGoalDisplayCmd},

--- a/workspace_tests/src/rt/cmds/states_goal_read_cmd.rs
+++ b/workspace_tests/src/rt/cmds/states_goal_read_cmd.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{app_name, profile, AppName, FlowId, Profile},
+    cfg::{app_name, profile, FlowId},
     cmd::ctx::CmdCtx,
     cmd_model::CmdOutcome,
     rt::cmds::{StatesDiscoverCmd, StatesGoalReadCmd},

--- a/workspace_tests/src/rt_model/error.rs
+++ b/workspace_tests/src/rt_model/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     miette::{GraphicalReportHandler, GraphicalTheme},
     params::{ParamsSpec, ParamsSpecs},
     rt_model::Error,

--- a/workspace_tests/src/rt_model/error.rs
+++ b/workspace_tests/src/rt_model/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     miette::{GraphicalReportHandler, GraphicalTheme},
     params::{ParamsSpec, ParamsSpecs},
     rt_model::Error,

--- a/workspace_tests/src/rt_model/item_boxed.rs
+++ b/workspace_tests/src/rt_model/item_boxed.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     data::{DataAccessDyn, TypeIds},
     rt_model::{ItemBoxed, ItemRt},
 };

--- a/workspace_tests/src/rt_model/item_boxed.rs
+++ b/workspace_tests/src/rt_model/item_boxed.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     data::{DataAccessDyn, TypeIds},
     rt_model::{ItemBoxed, ItemRt},
 };

--- a/workspace_tests/src/rt_model/item_graph.rs
+++ b/workspace_tests/src/rt_model/item_graph.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id},
+    cfg::item_id,
     resources::{
         internal::StatesMut,
         states::{StatesCurrent, StatesSerde},

--- a/workspace_tests/src/rt_model/item_graph.rs
+++ b/workspace_tests/src/rt_model/item_graph.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId},
+    cfg::{item_id},
     resources::{
         internal::StatesMut,
         states::{StatesCurrent, StatesSerde},

--- a/workspace_tests/src/rt_model/item_wrapper.rs
+++ b/workspace_tests/src/rt_model/item_wrapper.rs
@@ -1,6 +1,6 @@
 use diff::{VecDiff, VecDiffType};
 use peace::{
-    cfg::{item_id, ApplyCheck, FnCtx, ItemId},
+    cfg::{item_id, ApplyCheck, FnCtx},
     data::marker::{ApplyDry, Clean, Current, Goal},
     params::{ParamsSpec, ParamsSpecs},
     resources::{

--- a/workspace_tests/src/rt_model/output/cli_output.rs
+++ b/workspace_tests/src/rt_model/output/cli_output.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{item_id, ItemId, State},
+    cfg::{item_id, State},
     resources::{
         internal::{StateDiffsMut, StatesMut},
         states::{StateDiffs, StatesCurrentStored},

--- a/workspace_tests/src/rt_model/states_serializer.rs
+++ b/workspace_tests/src/rt_model/states_serializer.rs
@@ -1,5 +1,5 @@
 use peace::{
-    cfg::{flow_id, item_id, FlowId, ItemId},
+    cfg::{flow_id, item_id},
     resources::{
         internal::StatesMut, paths::StatesCurrentFile, states::StatesCurrentStored,
         type_reg::untagged::TypeReg,

--- a/workspace_tests/src/rt_model/workspace_dirs_builder.rs
+++ b/workspace_tests/src/rt_model/workspace_dirs_builder.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use peace::{
-    cfg::{app_name},
+    cfg::app_name,
     rt_model::{Error, NativeError, WorkspaceDirsBuilder, WorkspaceSpec},
 };
 

--- a/workspace_tests/src/rt_model/workspace_dirs_builder.rs
+++ b/workspace_tests/src/rt_model/workspace_dirs_builder.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use peace::{
-    cfg::{app_name, AppName},
+    cfg::{app_name},
     rt_model::{Error, NativeError, WorkspaceDirsBuilder, WorkspaceSpec},
 };
 


### PR DESCRIPTION
Closes #157.

Automatic fix of most imports:

```bash
cargo fix --workspace \
  --features "cli error_reporting output_progress" \
  --exclude peace_rt_model_web
```

The `download` example's `wasm.rs` was manually fixed.