### PR TITLE
Update dependency versions -- including up to `leptos 0.7.4`.

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,6 +3,12 @@ ignore = [
   # `proc-macro-error` is Unmaintained.
   #
   # Transitive dependency of `syn_derive`.
-  # Pending https://github.com/Kyuuhachi/syn_derive/issues/4.
+  # Pending <https://github.com/rs-tml/rstml/issues/56>.
   "RUSTSEC-2024-0370",
+
+  # `derivative` is unmaintained.
+  #
+  # Transitive dependency of `log4rs`.
+  # Pending <https://github.com/estk/log4rs/issues/391>.
+  "RUSTSEC-2024-0388",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Render progress and outcome diagram using `dot_ix`. ([#182], [#189], [#191])
 * Experimented renaming `Item` trait to `Step` (reverted). ([#187], [#192])
 * Rename `peace_resources` crate to `peace_resource_rt`. ([#182], [#187], [#193], [#194])
+* Add experimental web frontend using `leptos 0.7`. ([#182], [#197], [#200])
 
 
 [#182]: https://github.com/azriel91/peace/issues/182
@@ -16,6 +17,8 @@
 [#192]: https://github.com/azriel91/peace/pull/192
 [#193]: https://github.com/azriel91/peace/pull/193
 [#194]: https://github.com/azriel91/peace/pull/194
+[#197]: https://github.com/azriel91/peace/pull/197
+[#200]: https://github.com/azriel91/peace/pull/200
 
 
 ## 0.0.13 (2024-02-03)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,58 +163,59 @@ peace_item_tar_x = { path = "items/tar_x", version = "0.0.13" }
 #
 # This does not include examples' dependencies, because we want it to be easy for
 # developers to see the dependencies to create an automation tool.
-async-trait = "0.1.81"
-axum = "0.7.5"
+async-trait = "0.1.85"
+axum = "0.7.9"
 base64 = "0.22.1"
-bytes = "1.7.1"
+bytes = "1.9.0"
 cfg-if = "1.0.0"
-chrono = { version = "0.4.38", default-features = false, features = ["clock", "serde"] }
-console = "0.15.8"
+chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde"] }
+console = "0.15.10"
 derivative = "2.2.0"
 diff-struct = "0.5.3"
-dot_ix = { version = "0.8.1", default-features = false }
-dot_ix_model = "0.8.1"
-downcast-rs = "1.2.1"
+dot_ix = { version = "0.9.1", default-features = false }
+dot_ix_model = "0.9.1"
+downcast-rs = "2.0.1"
 dyn-clone = "1.0.17"
 enser = "0.1.4"
 erased-serde = "0.4.5"
-fn_graph = { version = "0.13.3", features = ["async", "graph_info", "interruptible", "resman"] }
-futures = "0.3.30"
+fn_graph = { version = "0.15.0", features = ["async", "graph_info", "interruptible", "resman"] }
+futures = "0.3.31"
 gloo-timers = "0.3.0"
 heck = "0.5.0"
-indexmap = "2.5.0"
-indicatif = "0.17.8"
+indexmap = "2.7.0"
+indicatif = "0.17.9"
 interruptible = "0.2.4"
-leptos = { version = "0.6" }
-leptos_axum = "0.6"
-leptos_meta = { version = "0.6" }
-leptos_router = { version = "0.6" }
-libc = "0.2.158"
-miette = "7.2.0"
+leptos = { version = "0.7" }
+leptos_axum = "0.7"
+leptos_config = "0.7"
+leptos_meta = { version = "0.7" }
+leptos_router = { version = "0.7" }
+libc = "0.2.169"
+miette = "7.4.0"
 own = "0.1.3"
-pretty_assertions = "1.4.0"
-proc-macro2 = "1.0.86"
-quote = "1.0.37"
+pretty_assertions = "1.4.1"
+proc-macro2 = "1.0.93"
+quote = "1.0.38"
 raw_tty = "0.1.0"
-reqwest = "0.12.7"
-resman = "0.17.2"
-serde = "1.0.209"
+reqwest = "0.12.12"
+resman = "0.18.0"
+serde = "1.0.217"
 serde-wasm-bindgen = "0.6.5"
-serde_json = "1.0.127"
+serde_json = "1.0.135"
 serde_yaml = "0.9.34"
 smallvec = "1.13.2"
-syn = "2.0.77"
-tar = "0.4.41"
-tempfile = "3.12.0"
-thiserror = "1.0.63"
-tokio = "1.40"
-tokio-util = "0.7.11"
-tower-http = "0.5.2"
+syn = "2.0.96"
+tar = "0.4.43"
+tempfile = "3.15.0"
+thiserror = "2.0.11"
+tokio = "1.43"
+tokio-util = "0.7.13"
+tower-http = "0.6.2"
 tynm = "0.1.10"
-type_reg = { version = "0.7.0", features = ["debug", "untagged", "ordered"] }
-url = "2.5.2"
-wasm-bindgen = "0.2.95"
-web-sys = "0.3.70"
+type_reg = { version = "0.8.0", features = ["debug", "untagged", "ordered"] }
+url = "2.5.4"
+wasm-bindgen = "0.2.99"
+web-sys = "0.3.76"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,8 +214,8 @@ tower-http = "0.6.2"
 tynm = "0.1.10"
 type_reg = { version = "0.8.0", features = ["debug", "untagged", "ordered"] }
 url = "2.5.4"
-wasm-bindgen = "0.2.99"
-web-sys = "0.3.76"
+wasm-bindgen = "0.2.100"
+web-sys = "0.3.77"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/about.toml
+++ b/about.toml
@@ -15,3 +15,17 @@ accepted = [
 # `cbindgen` has MPL-2.0 as a build dependency, which doesn't apply to our
 # compiled software.
 ignore-build-dependencies = true
+
+# `cargo-about generate licenses` fails on `ring`:
+#
+# ```
+# error: failed to satisfy license requirements
+#     ┌─ /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ring-0.17.8/Cargo.toml:171:79
+#     │
+# 171 │ license = "((ISC AND (OpenSSL AND ISC)) AND (MIT AND OpenSSL) AND OpenSSL AND OpenSSL-standalone AND (SSLeay-standalone AND ISC AND MIT) AND MIT) AND (ISC) AND (ISC AND (ISC AND (OpenSSL AND ISC) AND MIT AND OpenSSL AND OpenSSL-standalone AND SSLeay-standalone)) AND (ISC AND (OpenSSL AND ISC) AND MIT AND OpenSSL AND OpenSSL-standalone AND SSLeay-standalone) AND (ISC AND LicenseRef-scancode-public-domain) AND (LicenseRef-scancode-unknown-license-reference) AND (MIT) AND (OpenSSL) AND (OpenSSL AND ((OpenSSL OR BSD-3-Clause) AND GPL-1.0-or-later)) AND (OpenSSL AND (OpenSSL OR BSD-3-Clause OR GPL-1.0-or-later OR GPL-2.0-only)) AND (OpenSSL AND (OpenSSL OR BSD-3-Clause OR GPL-1.0-or-later)) AND (OpenSSL AND (OpenSSL OR BSD-3-Clause)) AND (OpenSSL-standalone) AND (SSLeay-standalone) AND (SSLeay-standalone AND OpenSSL-standalone)"
+#     │                                                                               ------------------      -----------------                                                                                                     ------------------     -----------------                                                          ------------------     -----------------               ---------------------------------       ---------------------------------------------                                                                          ----------------                                                ----------------    ------------                                                ----------------                                                    ------------------       -----------------       -----------------     ------------------
+# 
+# 2025-01-17 5:30:42.442908775 +00:00:00 [ERROR] encountered 1 errors resolving licenses, unable to generate output
+# Error: Process completed with exit code 1.
+# ```
+workarounds = ["ring"]

--- a/about.toml
+++ b/about.toml
@@ -11,3 +11,7 @@ accepted = [
     "OpenSSL",
     "Zlib",
 ]
+
+# `cbindgen` has MPL-2.0 as a build dependency, which doesn't apply to our
+# compiled software.
+ignore-build-dependencies = true

--- a/crate/cli/src/output/cli_output.rs
+++ b/crate/cli/src/output/cli_output.rs
@@ -230,7 +230,7 @@ where
         Ok(())
     }
 
-    async fn output_yaml<'f, E, T, F>(&mut self, t: &T, fn_error: F) -> Result<(), E>
+    async fn output_yaml<E, T, F>(&mut self, t: &T, fn_error: F) -> Result<(), E>
     where
         E: std::error::Error + From<Error>,
         T: Serialize + ?Sized,
@@ -247,7 +247,7 @@ where
         Ok(())
     }
 
-    async fn output_json<'f, E, T, F>(&mut self, t: &T, fn_error: F) -> Result<(), E>
+    async fn output_json<E, T, F>(&mut self, t: &T, fn_error: F) -> Result<(), E>
     where
         E: std::error::Error + From<Error>,
         T: Serialize + ?Sized,

--- a/crate/cmd_rt/src/cmd_execution.rs
+++ b/crate/cmd_rt/src/cmd_execution.rs
@@ -67,9 +67,9 @@ where
     }
 
     /// Returns the result of executing the command.
-    pub async fn exec<'ctx>(
+    pub async fn exec(
         &mut self,
-        cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'ctx, CmdCtxTypesT>>,
+        cmd_ctx: &mut CmdCtx<SingleProfileSingleFlow<'_, CmdCtxTypesT>>,
     ) -> Result<
         CmdOutcome<ExecutionOutcome, <CmdCtxTypesT as CmdCtxTypesConstrained>::AppError>,
         <CmdCtxTypesT as CmdCtxTypesConstrained>::AppError,

--- a/crate/flow_model/src/flow_spec_info.rs
+++ b/crate/flow_model/src/flow_spec_info.rs
@@ -2,7 +2,7 @@ use dot_ix::model::{
     common::{EdgeId, Edges, NodeHierarchy, NodeId, NodeNames},
     info_graph::{GraphDir, GraphStyle, InfoGraph},
 };
-use fn_graph::{daggy::Walker, Edge, GraphInfo};
+use fn_graph::{daggy2::Walker, Edge, GraphInfo};
 use peace_core::FlowId;
 use serde::{Deserialize, Serialize};
 

--- a/crate/params/src/any_spec_data_type.rs
+++ b/crate/params/src/any_spec_data_type.rs
@@ -2,13 +2,14 @@
 
 use std::{any::Any, fmt};
 
+use downcast_rs::DowncastSync;
 use dyn_clone::DynClone;
 use peace_resource_rt::type_reg::untagged::DataType;
 
 use crate::AnySpecRt;
 
 /// A [`DataType`] that is also an [`AnySpecRt`].
-pub trait AnySpecDataType: DataType + AnySpecRt {}
+pub trait AnySpecDataType: AnySpecRt + DataType + DowncastSync {}
 
 impl<T> AnySpecDataType for T where
     T: Any + DynClone + fmt::Debug + AnySpecRt + erased_serde::Serialize + Send + Sync

--- a/crate/webi_components/src/app.rs
+++ b/crate/webi_components/src/app.rs
@@ -1,6 +1,15 @@
-use leptos::{component, view, IntoView};
+use std::time::Duration;
+
+use leptos::{
+    component,
+    prelude::{signal, ClassAttribute, ElementChild, Get},
+    view, IntoView,
+};
 use leptos_meta::{provide_meta_context, Link, Stylesheet};
-use leptos_router::{Route, Router, Routes};
+use leptos_router::{
+    components::{Route, Router, Routes, RoutingProgress},
+    StaticSegment,
+};
 
 use crate::ChildrenFn;
 
@@ -10,7 +19,7 @@ use crate::ChildrenFn;
 ///
 /// * `flow_component`: The web component to render for the flow.
 #[component]
-pub fn Home(app_home: ChildrenFn) -> impl IntoView {
+pub fn App(app_home: ChildrenFn) -> impl IntoView {
     // Provides context that manages stylesheets, titles, meta tags, etc.
     provide_meta_context();
 
@@ -18,18 +27,33 @@ pub fn Home(app_home: ChildrenFn) -> impl IntoView {
     let favicon_path = format!("{site_prefix}/webi/favicon.ico");
     let fonts_path = format!("{site_prefix}/webi/fonts/fonts.css");
 
+    let (is_routing, set_is_routing) = signal(false);
+
     view! {
         <Link rel="shortcut icon" type_="image/ico" href=favicon_path />
         <Stylesheet id="fonts" href=fonts_path />
-        <Router>
+        <Router set_is_routing>
+            <div class="routing-progress">
+                <RoutingProgress is_routing max_time=Duration::from_millis(250)/>
+            </div>
             <main>
-                <Routes>
+                <Routes fallback=RouterFallback>
                     <Route
-                        path=site_prefix
+                        path=StaticSegment(site_prefix)
                         view=move || app_home.call()
                     />
                 </Routes>
             </main>
         </Router>
+    }
+}
+
+#[component]
+fn RouterFallback() -> impl IntoView {
+    let location = leptos_router::hooks::use_location();
+    let pathname = move || location.pathname.get();
+
+    view! {
+        <p>"Path not found: " {pathname}</p>
     }
 }

--- a/crate/webi_components/src/children_fn.rs
+++ b/crate/webi_components/src/children_fn.rs
@@ -1,6 +1,10 @@
 use std::{fmt, sync::Arc};
 
-use leptos::{Fragment, IntoView, ToChildren};
+use leptos::{
+    children::ToChildren,
+    prelude::{AnyView, IntoAny, Render},
+    IntoView,
+};
 
 /// Allows a consumer to pass in the view fragment for a
 /// [`leptos_router::Route`].
@@ -15,25 +19,26 @@ use leptos::{Fragment, IntoView, ToChildren};
 /// When we migrate to `leptos 0.7`, `ChildrenFn` is an alias for `Arc<_>` so we
 /// can use it directly.
 #[derive(Clone)]
-pub struct ChildrenFn(Arc<dyn Fn() -> Fragment + Send + Sync>);
+pub struct ChildrenFn(Arc<dyn Fn() -> AnyView + Send + Sync>);
 
 impl ChildrenFn {
     /// Returns a new `ChildrenFn`;
     pub fn new<F, IV>(f: F) -> Self
     where
         F: Fn() -> IV + Send + Sync + 'static,
-        IV: IntoView,
+        IV: IntoView + 'static,
+        <IV as Render>::State: 'static,
     {
-        Self(Arc::new(move || Fragment::from(f().into_view())))
+        Self(Arc::new(move || f().into_view().into_any()))
     }
 
     /// Returns the underlying function.
-    pub fn into_inner(self) -> Arc<dyn Fn() -> Fragment + Send + Sync> {
+    pub fn into_inner(self) -> Arc<dyn Fn() -> AnyView + Send + Sync> {
         self.0
     }
 
     /// Calls the inner function to render the view.
-    pub fn call(&self) -> Fragment {
+    pub fn call(&self) -> AnyView {
         (self.0)()
     }
 }
@@ -41,14 +46,14 @@ impl ChildrenFn {
 impl fmt::Debug for ChildrenFn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("ChildrenFn")
-            .field(&"Arc<dyn Fn() -> Fragment + Send + Sync>")
+            .field(&"Arc<dyn Fn() -> AnyView + Send + Sync>")
             .finish()
     }
 }
 
 impl<F> ToChildren<F> for ChildrenFn
 where
-    F: Fn() -> Fragment + 'static + Send + Sync,
+    F: Fn() -> AnyView + 'static + Send + Sync,
 {
     #[inline]
     fn to_children(f: F) -> Self {

--- a/crate/webi_components/src/flow_graph.rs
+++ b/crate/webi_components/src/flow_graph.rs
@@ -3,7 +3,11 @@ use dot_ix::{
     rt::IntoGraphvizDotSrc,
     web_components::DotSvg,
 };
-use leptos::{component, server, view, IntoView, ServerFnError, SignalSet, Transition};
+use leptos::{
+    component,
+    prelude::{ClassAttribute, ElementChild, ServerFnError, Set, Transition},
+    server, view, IntoView,
+};
 
 /// Renders the flow graph.
 ///
@@ -25,18 +29,19 @@ pub fn FlowGraph() -> impl IntoView {
 
 #[server]
 async fn progress_info_graph_fetch() -> Result<InfoGraph, ServerFnError> {
-    use leptos::{ReadSignal, SignalGet};
+    use leptos::prelude::{Get, ReadSignal};
     use peace_core::FlowId;
     use peace_webi_model::FlowProgressInfoGraphs;
 
-    let flow_id = leptos::use_context::<ReadSignal<FlowId>>();
-    let flow_progress_info_graphs = leptos::use_context::<FlowProgressInfoGraphs<FlowId>>();
+    let flow_id = leptos::prelude::use_context::<ReadSignal<FlowId>>();
+    let flow_progress_info_graphs =
+        leptos::prelude::use_context::<FlowProgressInfoGraphs<FlowId>>();
     let progress_info_graph = if let Some(flow_progress_info_graphs) = flow_progress_info_graphs {
         let flow_progress_info_graphs = flow_progress_info_graphs.lock().ok();
 
         flow_id
             .as_ref()
-            .map(SignalGet::get)
+            .map(Get::get)
             .zip(flow_progress_info_graphs)
             .and_then(|(flow_id, flow_progress_info_graphs)| {
                 flow_progress_info_graphs.get(&flow_id).cloned()
@@ -52,25 +57,21 @@ async fn progress_info_graph_fetch() -> Result<InfoGraph, ServerFnError> {
 #[component]
 fn ProgressGraph() -> impl IntoView {
     let (progress_info_graph, progress_info_graph_set) =
-        leptos::create_signal(InfoGraph::default());
-    let (dot_src_and_styles, dot_src_and_styles_set) = leptos::create_signal(None);
+        leptos::prelude::signal(InfoGraph::default());
+    let (dot_src_and_styles, dot_src_and_styles_set) = leptos::prelude::signal(None);
 
-    leptos::create_local_resource(
-        move || (),
-        move |()| async move {
-            let progress_info_graph = progress_info_graph_fetch().await.unwrap_or_default();
-            let dot_src_and_styles =
-                IntoGraphvizDotSrc::into(&progress_info_graph, &GraphvizDotTheme::default());
+    leptos::prelude::LocalResource::new(move || async move {
+        let progress_info_graph = progress_info_graph_fetch().await.unwrap_or_default();
+        let dot_src_and_styles =
+            IntoGraphvizDotSrc::into(&progress_info_graph, &GraphvizDotTheme::default());
 
-            if let Ok(progress_info_graph_serialized) = serde_yaml::to_string(&progress_info_graph)
-            {
-                leptos::logging::log!("{progress_info_graph_serialized}");
-            }
+        if let Ok(progress_info_graph_serialized) = serde_yaml::to_string(&progress_info_graph) {
+            leptos::logging::log!("{progress_info_graph_serialized}");
+        }
 
-            progress_info_graph_set.set(progress_info_graph);
-            dot_src_and_styles_set.set(Some(dot_src_and_styles));
-        },
-    );
+        progress_info_graph_set.set(progress_info_graph);
+        dot_src_and_styles_set.set(Some(dot_src_and_styles));
+    });
 
     view! {
         <Transition fallback=move || view! { <p>"Loading graph..."</p> }>
@@ -84,18 +85,18 @@ fn ProgressGraph() -> impl IntoView {
 
 #[server]
 async fn outcome_info_graph_fetch() -> Result<InfoGraph, ServerFnError> {
-    use leptos::{ReadSignal, SignalGet};
+    use leptos::prelude::{Get, ReadSignal};
     use peace_core::FlowId;
     use peace_webi_model::FlowOutcomeInfoGraphs;
 
-    let flow_id = leptos::use_context::<ReadSignal<FlowId>>();
-    let flow_outcome_info_graphs = leptos::use_context::<FlowOutcomeInfoGraphs<FlowId>>();
+    let flow_id = leptos::prelude::use_context::<ReadSignal<FlowId>>();
+    let flow_outcome_info_graphs = leptos::prelude::use_context::<FlowOutcomeInfoGraphs<FlowId>>();
     let outcome_info_graph = if let Some(flow_outcome_info_graphs) = flow_outcome_info_graphs {
         let flow_outcome_info_graphs = flow_outcome_info_graphs.lock().ok();
 
         flow_id
             .as_ref()
-            .map(SignalGet::get)
+            .map(Get::get)
             .zip(flow_outcome_info_graphs)
             .and_then(|(flow_id, flow_outcome_info_graphs)| {
                 flow_outcome_info_graphs.get(&flow_id).cloned()
@@ -110,24 +111,22 @@ async fn outcome_info_graph_fetch() -> Result<InfoGraph, ServerFnError> {
 
 #[component]
 fn OutcomeGraph() -> impl IntoView {
-    let (outcome_info_graph, outcome_info_graph_set) = leptos::create_signal(InfoGraph::default());
-    let (dot_src_and_styles, dot_src_and_styles_set) = leptos::create_signal(None);
+    let (outcome_info_graph, outcome_info_graph_set) =
+        leptos::prelude::signal(InfoGraph::default());
+    let (dot_src_and_styles, dot_src_and_styles_set) = leptos::prelude::signal(None);
 
-    leptos::create_local_resource(
-        move || (),
-        move |()| async move {
-            let outcome_info_graph = outcome_info_graph_fetch().await.unwrap_or_default();
-            let dot_src_and_styles =
-                IntoGraphvizDotSrc::into(&outcome_info_graph, &GraphvizDotTheme::default());
+    leptos::prelude::LocalResource::new(move || async move {
+        let outcome_info_graph = outcome_info_graph_fetch().await.unwrap_or_default();
+        let dot_src_and_styles =
+            IntoGraphvizDotSrc::into(&outcome_info_graph, &GraphvizDotTheme::default());
 
-            if let Ok(outcome_info_graph_serialized) = serde_yaml::to_string(&outcome_info_graph) {
-                leptos::logging::log!("{outcome_info_graph_serialized}");
-            }
+        if let Ok(outcome_info_graph_serialized) = serde_yaml::to_string(&outcome_info_graph) {
+            leptos::logging::log!("{outcome_info_graph_serialized}");
+        }
 
-            outcome_info_graph_set.set(outcome_info_graph);
-            dot_src_and_styles_set.set(Some(dot_src_and_styles));
-        },
-    );
+        outcome_info_graph_set.set(outcome_info_graph);
+        dot_src_and_styles_set.set(Some(dot_src_and_styles));
+    });
 
     view! {
         <Transition fallback=move || view! { <p>"Loading graph..."</p> }>

--- a/crate/webi_components/src/lib.rs
+++ b/crate/webi_components/src/lib.rs
@@ -2,12 +2,15 @@
 
 //! Web interface components for the peace automation framework.
 
+pub use leptos;
+
 pub use crate::{
-    children_fn::ChildrenFn, flow_graph::FlowGraph, flow_graph_current::FlowGraphCurrent,
-    home::Home,
+    app::App, children_fn::ChildrenFn, flow_graph::FlowGraph, flow_graph_current::FlowGraphCurrent,
+    shell::Shell,
 };
 
+mod app;
 mod children_fn;
 mod flow_graph;
 mod flow_graph_current;
-mod home;
+mod shell;

--- a/crate/webi_components/src/shell.rs
+++ b/crate/webi_components/src/shell.rs
@@ -3,7 +3,7 @@ use leptos::{
     prelude::{ElementChild, GlobalAttributes, IntoView, LeptosOptions},
     view,
 };
-use leptos_meta::{MetaTags, Stylesheet, Title};
+use leptos_meta::{provide_meta_context, MetaTags, Stylesheet, Title};
 
 use crate::{App, ChildrenFn};
 
@@ -17,6 +17,14 @@ use crate::{App, ChildrenFn};
 /// * `options`: The `LeptosOptions` from
 ///   `leptos::prelude::get_configuration(None)?.leptos_options`.
 pub fn Shell(app_name: String, options: LeptosOptions, app_home: ChildrenFn) -> impl IntoView {
+    // Provides context that manages stylesheets, titles, meta tags, etc.
+    //
+    // Normally this is in the `App` component, but for `peace_webi_components`, we
+    // also include it in the `Shell` because the `Title` component calls
+    // `leptos_meta::use_head()`, which logs a debug message about the meta context
+    // not being provided.
+    provide_meta_context();
+
     view! {
         <!DOCTYPE html>
         <html lang="en">

--- a/crate/webi_components/src/shell.rs
+++ b/crate/webi_components/src/shell.rs
@@ -1,0 +1,41 @@
+use leptos::{
+    hydration::{AutoReload, HydrationScripts},
+    prelude::{ElementChild, GlobalAttributes, IntoView, LeptosOptions},
+    view,
+};
+use leptos_meta::{MetaTags, Stylesheet, Title};
+
+use crate::{App, ChildrenFn};
+
+/// Main shell for server side rendered app.
+///
+/// # Parameters
+///
+/// * `app_name`: The name that `leptos` will compile the server side binary to.
+///   Usually the crate name, but may be changed by the `output-name` key in
+///   `Cargo.toml`.
+/// * `options`: The `LeptosOptions` from
+///   `leptos::prelude::get_configuration(None)?.leptos_options`.
+pub fn Shell(app_name: String, options: LeptosOptions, app_home: ChildrenFn) -> impl IntoView {
+    view! {
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <AutoReload options=options.clone() />
+                <HydrationScripts options />
+                <MetaTags />
+
+                <Title text=format!("{app_name} • peace")/>
+
+                // injects a stylesheet into the document <head>
+                // id=leptos means cargo-leptos will hot-reload this stylesheet
+                <Stylesheet id="leptos" href=format!("/pkg/{app_name}.css") />
+            </head>
+            <body>
+                <App app_home />
+            </body>
+        </html>
+    }
+}

--- a/crate/webi_model/Cargo.toml
+++ b/crate/webi_model/Cargo.toml
@@ -23,6 +23,7 @@ test = false
 cfg-if = { workspace = true }
 dot_ix_model = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
+leptos_config = { workspace = true }
 miette = { workspace = true, optional = true }
 peace_core = { workspace = true }
 peace_cmd_model = { workspace = true }

--- a/crate/webi_model/src/webi_error.rs
+++ b/crate/webi_model/src/webi_error.rs
@@ -36,6 +36,22 @@ pub enum WebiError {
         error: std::io::Error,
     },
 
+    /// Failed to read leptos configuration.
+    ///
+    /// This may be a bug in the Peace framework or `leptos`.
+    #[error("Failed to read leptos configuration. This may be a bug in the Peace framework or `leptos`.")]
+    #[cfg_attr(
+        feature = "error_reporting",
+        diagnostic(
+            code(peace_webi_model::leptos_config_read),
+            help("Ask for help on Discord.")
+        )
+    )]
+    LeptosConfigRead {
+        /// The underlying error.
+        error: leptos_config::errors::LeptosConfigError,
+    },
+
     /// Failed to start web server for Web interface.
     #[error("Failed to start web server for Web interface on socket: {socket_addr}")]
     #[cfg_attr(

--- a/deny.toml
+++ b/deny.toml
@@ -73,8 +73,14 @@ ignore = [
     # `proc-macro-error` is Unmaintained.
     #
     # Transitive dependency of `syn_derive`.
-    # Pending https://github.com/Kyuuhachi/syn_derive/issues/4.
+    # Pending <https://github.com/rs-tml/rstml/issues/56>.
     "RUSTSEC-2024-0370",
+
+    # `derivative` is unmaintained.
+    #
+    # Transitive dependency of `log4rs`.
+    # Pending <https://github.com/estk/log4rs/issues/391>.
+    "RUSTSEC-2024-0388",
 ]
 
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
@@ -101,6 +107,7 @@ allow = [
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "NOASSERTION",
     "OpenSSL",
     "Zlib",

--- a/examples/download/Cargo.toml
+++ b/examples/download/Cargo.toml
@@ -19,23 +19,23 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 peace_items = { path = "../../items", features = ["file_download"] }
-thiserror = "1.0.63"
-url = { version = "2.5.2", features = ["serde"] }
+thiserror = "2.0.11"
+url = { version = "2.5.4", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 peace = { workspace = true, default-features = false, features = ["cli"] }
-clap = { version = "4.5.16", features = ["derive"] }
-tokio = { version = "1.40.0", features = ["net", "time", "rt"] }
+clap = { version = "4.5.26", features = ["derive"] }
+tokio = { version = "1.43.0", features = ["net", "time", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 peace = { workspace = true, default-features = false }
 console_error_panic_hook = "0.1.7"
 serde-wasm-bindgen = "0.6.5"
-tokio = "1.40.0"
-wasm-bindgen = "0.2.95"
-wasm-bindgen-futures = "0.4.43"
-js-sys = "0.3.70"
-web-sys = "0.3.70"
+tokio = "1.43.0"
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
+js-sys = "0.3.76"
+web-sys = "0.3.76"
 
 [features]
 default = []

--- a/examples/download/Cargo.toml
+++ b/examples/download/Cargo.toml
@@ -32,10 +32,10 @@ peace = { workspace = true, default-features = false }
 console_error_panic_hook = "0.1.7"
 serde-wasm-bindgen = "0.6.5"
 tokio = "1.43.0"
-wasm-bindgen = "0.2.99"
-wasm-bindgen-futures = "0.4.49"
-js-sys = "0.3.76"
-web-sys = "0.3.76"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
+js-sys = "0.3.77"
+web-sys = "0.3.77"
 
 [features]
 default = []

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -18,10 +18,10 @@ test = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aws-config = { version = "1.5.13", optional = true }
-aws-sdk-iam = { version = "1.56.0", optional = true }
-aws-sdk-s3 = { version = "1.68.0", optional = true }
-aws-smithy-types = { version = "1.2.11", optional = true } # used to reference error type, otherwise not recommended for direct usage
+aws-config = { version = "1.5.14", optional = true }
+aws-sdk-iam = { version = "1.57.0", optional = true }
+aws-sdk-s3 = { version = "1.69.0", optional = true }
+aws-smithy-types = { version = "1.2.12", optional = true } # used to reference error type, otherwise not recommended for direct usage
 base64 = { version = "0.22.1", optional = true }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde"], optional = true }
@@ -41,10 +41,10 @@ whoami = { version = "1.5.2", optional = true }
 # ssr
 axum = { version = "0.7.9", optional = true }
 hyper = { version = "1.5.2", optional = true }
-leptos = { version = "0.7.3", default-features = false }
-leptos_axum = { version = "0.7.3", optional = true }
-leptos_meta = { version = "0.7.3", default-features = false }
-leptos_router = { version = "0.7.3", default-features = false }
+leptos = { version = "0.7.4", default-features = false }
+leptos_axum = { version = "0.7.4", optional = true }
+leptos_meta = { version = "0.7.4", default-features = false }
+leptos_router = { version = "0.7.4", default-features = false }
 tower = { version = "0.5.2", optional = true }
 tower-http = { version = "0.6.2", optional = true, features = ["fs"] }
 tracing = { version = "0.1.41", optional = true }
@@ -56,13 +56,13 @@ tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "signal"], op
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
-log = "0.4.22"
+log = "0.4.25"
 serde-wasm-bindgen = "0.6.5"
 tokio = "1.43.0"
-wasm-bindgen = "0.2.99"
-wasm-bindgen-futures = "0.4.49"
-js-sys = "0.3.76"
-web-sys = "0.3.76"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
+js-sys = "0.3.77"
+web-sys = "0.3.77"
 
 [features]
 default = ["item_interactions", "item_state_example"]

--- a/examples/envman/Cargo.toml
+++ b/examples/envman/Cargo.toml
@@ -18,51 +18,51 @@ test = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aws-config = { version = "1.5.5", optional = true }
-aws-sdk-iam = { version = "1.42.0", optional = true }
-aws-sdk-s3 = { version = "1.47.0", optional = true }
-aws-smithy-types = { version = "1.2.4", optional = true } # used to reference error type, otherwise not recommended for direct usage
+aws-config = { version = "1.5.13", optional = true }
+aws-sdk-iam = { version = "1.56.0", optional = true }
+aws-sdk-s3 = { version = "1.68.0", optional = true }
+aws-smithy-types = { version = "1.2.11", optional = true } # used to reference error type, otherwise not recommended for direct usage
 base64 = { version = "0.22.1", optional = true }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.38", default-features = false, features = ["clock", "serde"], optional = true }
+chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde"], optional = true }
 derivative = { version = "2.2.0", optional = true }
-futures = { version = "0.3.30", optional = true }
+futures = { version = "0.3.31", optional = true }
 md5-rs = { version = "0.1.5", optional = true }  # WASM compatible, and reads bytes as stream
 peace = { path = "../..", default-features = false }
 peace_items = { path = "../../items", features = ["file_download"] }
-semver = { version = "1.0.23", optional = true }
-serde = { version = "1.0.209", features = ["derive"] }
-thiserror = { version = "1.0.63", optional = true }
-url = { version = "2.5.2", features = ["serde"] }
+semver = { version = "1.0.24", optional = true }
+serde = { version = "1.0.217", features = ["derive"] }
+thiserror = { version = "2.0.11", optional = true }
+url = { version = "2.5.4", features = ["serde"] }
 urlencoding = { version = "2.1.3", optional = true }
-whoami = { version = "1.5.1", optional = true }
+whoami = { version = "1.5.2", optional = true }
 
 # web_server
 # ssr
-axum = { version = "0.7.5", optional = true }
-hyper = { version = "1.4.1", optional = true }
-leptos = { version = "0.6.14", default-features = false, features = ["serde"] }
-leptos_axum = { version = "0.6.14", optional = true }
-leptos_meta = { version = "0.6.14", default-features = false }
-leptos_router = { version = "0.6.14", default-features = false }
-tower = { version = "0.5.0", optional = true }
-tower-http = { version = "0.5.2", optional = true, features = ["fs"] }
-tracing = { version = "0.1.40", optional = true }
+axum = { version = "0.7.9", optional = true }
+hyper = { version = "1.5.2", optional = true }
+leptos = { version = "0.7.3", default-features = false }
+leptos_axum = { version = "0.7.3", optional = true }
+leptos_meta = { version = "0.7.3", default-features = false }
+leptos_router = { version = "0.7.3", default-features = false }
+tower = { version = "0.5.2", optional = true }
+tower-http = { version = "0.6.2", optional = true, features = ["fs"] }
+tracing = { version = "0.1.41", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-clap = { version = "4.5.16", features = ["derive"], optional = true }
-tokio = { version = "1.40.0", features = ["rt", "rt-multi-thread", "signal"], optional = true }
+clap = { version = "4.5.26", features = ["derive"], optional = true }
+tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "signal"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 console_log = { version = "1.0.0", features = ["color"] }
 log = "0.4.22"
 serde-wasm-bindgen = "0.6.5"
-tokio = "1.40.0"
-wasm-bindgen = "0.2.95"
-wasm-bindgen-futures = "0.4.43"
-js-sys = "0.3.70"
-web-sys = "0.3.70"
+tokio = "1.43.0"
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
+js-sys = "0.3.76"
+web-sys = "0.3.76"
 
 [features]
 default = ["item_interactions", "item_state_example"]
@@ -152,8 +152,6 @@ web_server = [
 hydrate = [
     "dep:tracing",
     "leptos/hydrate",
-    "leptos_meta/hydrate",
-    "leptos_router/hydrate",
     "peace/webi",
 ]
 

--- a/examples/envman/src/lib.rs
+++ b/examples/envman/src/lib.rs
@@ -61,9 +61,8 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(feature = "hydrate")] {
         use wasm_bindgen::prelude::wasm_bindgen;
-        use leptos::*;
-
-        use peace::webi_components::{ChildrenFn, Home};
+        use leptos::prelude::view;
+        use peace::webi_components::{App, ChildrenFn};
 
         #[wasm_bindgen]
         pub async fn hydrate() {
@@ -75,9 +74,9 @@ cfg_if::cfg_if! {
 
             let app_home = ChildrenFn::new(EnvDeployHome);
 
-            leptos::mount_to_body(move || {
+            leptos::mount::hydrate_body(move || {
                 view! {
-                    <Home app_home />
+                    <App app_home />
                 }
             });
         }

--- a/examples/envman/src/main_cli.rs
+++ b/examples/envman/src/main_cli.rs
@@ -273,6 +273,7 @@ async fn run_command(
             };
 
             WebiServer::start(
+                env!("CARGO_CRATE_NAME").to_string(),
                 Some(SocketAddr::from((address, port))),
                 ChildrenFn::new(EnvDeployHome),
                 flow_webi_fns,

--- a/examples/envman/src/web_components/env_deploy_home.rs
+++ b/examples/envman/src/web_components/env_deploy_home.rs
@@ -1,4 +1,10 @@
-use leptos::{component, server, spawn_local, view, IntoView, ServerFnError};
+use leptos::{
+    component,
+    prelude::{ClassAttribute, ElementChild, OnAttribute, ServerFnError},
+    server,
+    task::spawn_local,
+    view, IntoView,
+};
 use peace::webi_components::{FlowGraph, FlowGraphCurrent};
 
 use crate::web_components::TabLabel;
@@ -9,7 +15,7 @@ async fn discover_cmd_exec() -> Result<(), ServerFnError> {
 
     use crate::web_components::CmdExecRequest;
 
-    let cmd_exec_request_tx = leptos::use_context::<mpsc::Sender<CmdExecRequest>>();
+    let cmd_exec_request_tx = leptos::context::use_context::<mpsc::Sender<CmdExecRequest>>();
 
     if let Some(cmd_exec_request_tx) = cmd_exec_request_tx {
         match cmd_exec_request_tx.try_send(CmdExecRequest::Discover) {
@@ -31,7 +37,7 @@ async fn deploy_cmd_exec() -> Result<(), ServerFnError> {
 
     use crate::web_components::CmdExecRequest;
 
-    let cmd_exec_request_tx = leptos::use_context::<mpsc::Sender<CmdExecRequest>>();
+    let cmd_exec_request_tx = leptos::context::use_context::<mpsc::Sender<CmdExecRequest>>();
 
     if let Some(cmd_exec_request_tx) = cmd_exec_request_tx {
         match cmd_exec_request_tx.try_send(CmdExecRequest::Ensure) {
@@ -53,7 +59,7 @@ async fn clean_cmd_exec() -> Result<(), ServerFnError> {
 
     use crate::web_components::CmdExecRequest;
 
-    let cmd_exec_request_tx = leptos::use_context::<mpsc::Sender<CmdExecRequest>>();
+    let cmd_exec_request_tx = leptos::context::use_context::<mpsc::Sender<CmdExecRequest>>();
 
     if let Some(cmd_exec_request_tx) = cmd_exec_request_tx {
         match cmd_exec_request_tx.try_send(CmdExecRequest::Clean) {

--- a/examples/envman/src/web_components/tab_label.rs
+++ b/examples/envman/src/web_components/tab_label.rs
@@ -1,4 +1,13 @@
-use leptos::{component, ev::Event, html, view, Callable, Callback, IntoView, NodeRef};
+use leptos::{
+    callback::{Callable, Callback},
+    component,
+    ev::Event,
+    html,
+    prelude::{
+        ClassAttribute, ElementChild, GlobalAttributes, NodeRef, NodeRefAttribute, OnAttribute,
+    },
+    view, IntoView,
+};
 
 /// The label that users click to switch to that tab.
 #[component]
@@ -9,9 +18,8 @@ pub fn TabLabel(
     #[prop(default = "")] class: &'static str,
     #[prop(default = false)] checked: bool,
     #[prop(into, optional, default = None)] on_change: Option<Callback<Event>>,
-    #[prop(into, optional, default = leptos::create_node_ref::<html::Input>())] node_ref: NodeRef<
-        html::Input,
-    >,
+    #[prop(into, optional, default = leptos::prelude::create_node_ref::<html::Input>())]
+    node_ref: NodeRef<html::Input>,
 ) -> impl IntoView {
     let tab_classes = format!(
         "\
@@ -49,7 +57,7 @@ pub fn TabLabel(
             id=tab_id
             class=tab_classes
             checked=checked
-            on:change={move |ev| { if let Some(on_change) = on_change { on_change.call(ev) } }}
+            on:change={move |ev| { if let Some(on_change) = on_change { on_change.run(ev) } }}
             node_ref=node_ref
         />
         <label for=tab_id class=label_classes>

--- a/workspace_tests/src/flow_model/flow_info.rs
+++ b/workspace_tests/src/flow_model/flow_info.rs
@@ -1,6 +1,6 @@
 use peace::{
     cfg::{flow_id, item_id},
-    data::fn_graph::{daggy::Dag, Edge, WouldCycle},
+    data::fn_graph::{daggy2::Dag, Edge, WouldCycle},
     flow_model::{FlowInfo, FlowSpecInfo, GraphInfo, ItemInfo, ItemSpecInfo},
     rt_model::{Flow, ItemGraph, ItemGraphBuilder},
 };

--- a/workspace_tests/src/flow_model/flow_info.rs
+++ b/workspace_tests/src/flow_model/flow_info.rs
@@ -24,7 +24,7 @@ fn debug() -> Result<(), Box<dyn std::error::Error>> {
         "FlowInfo { \
             flow_id: FlowId(\"flow_id\"), \
             graph_info: GraphInfo { \
-                graph: Dag { graph: Graph { Ty: \"Directed\", node_count: 6, edge_count: 9, edges: (0, 1), (0, 2), (1, 4), (2, 3), (3, 4), (5, 4), (1, 2), (5, 1), (0, 5), node weights: {0: ItemInfo { item_id: ItemId(\"a\") }, 1: ItemInfo { item_id: ItemId(\"b\") }, 2: ItemInfo { item_id: ItemId(\"c\") }, 3: ItemInfo { item_id: ItemId(\"d\") }, 4: ItemInfo { item_id: ItemId(\"e\") }, 5: ItemInfo { item_id: ItemId(\"f\") }}, edge weights: {0: Logic, 1: Logic, 2: Logic, 3: Logic, 4: Logic, 5: Logic, 6: Data, 7: Data, 8: Data} }, cycle_state: DfsSpace { dfs: Dfs { stack: [], discovered: FixedBitSet { data: [], length: 0 } } } } \
+                graph: Dag { graph: Graph { Ty: \"Directed\", node_count: 6, edge_count: 9, edges: (0, 1), (0, 2), (1, 4), (2, 3), (3, 4), (5, 4), (1, 2), (5, 1), (0, 5), node weights: {0: ItemInfo { item_id: ItemId(\"a\") }, 1: ItemInfo { item_id: ItemId(\"b\") }, 2: ItemInfo { item_id: ItemId(\"c\") }, 3: ItemInfo { item_id: ItemId(\"d\") }, 4: ItemInfo { item_id: ItemId(\"e\") }, 5: ItemInfo { item_id: ItemId(\"f\") }}, edge weights: {0: Logic, 1: Logic, 2: Logic, 3: Logic, 4: Logic, 5: Logic, 6: Data, 7: Data, 8: Data} }, cycle_state: DfsSpace { dfs: Dfs { stack: [], discovered: FixedBitSet { data: 0x10, capacity: 0, length: 0 } } } } \
             } \
         }",
         format!("{flow_info:?}")

--- a/workspace_tests/src/flow_model/flow_spec_info.rs
+++ b/workspace_tests/src/flow_model/flow_spec_info.rs
@@ -78,7 +78,7 @@ fn debug() -> Result<(), Box<dyn std::error::Error>> {
         "FlowSpecInfo { \
             flow_id: FlowId(\"flow_id\"), \
             graph_info: GraphInfo { \
-                graph: Dag { graph: Graph { Ty: \"Directed\", node_count: 6, edge_count: 9, edges: (0, 1), (0, 2), (1, 4), (2, 3), (3, 4), (5, 4), (1, 2), (5, 1), (0, 5), node weights: {0: ItemSpecInfo { item_id: ItemId(\"a\") }, 1: ItemSpecInfo { item_id: ItemId(\"b\") }, 2: ItemSpecInfo { item_id: ItemId(\"c\") }, 3: ItemSpecInfo { item_id: ItemId(\"d\") }, 4: ItemSpecInfo { item_id: ItemId(\"e\") }, 5: ItemSpecInfo { item_id: ItemId(\"f\") }}, edge weights: {0: Contains, 1: Logic, 2: Logic, 3: Contains, 4: Logic, 5: Logic, 6: Data, 7: Data, 8: Data} }, cycle_state: DfsSpace { dfs: Dfs { stack: [], discovered: FixedBitSet { data: [], length: 0 } } } } \
+                graph: Dag { graph: Graph { Ty: \"Directed\", node_count: 6, edge_count: 9, edges: (0, 1), (0, 2), (1, 4), (2, 3), (3, 4), (5, 4), (1, 2), (5, 1), (0, 5), node weights: {0: ItemSpecInfo { item_id: ItemId(\"a\") }, 1: ItemSpecInfo { item_id: ItemId(\"b\") }, 2: ItemSpecInfo { item_id: ItemId(\"c\") }, 3: ItemSpecInfo { item_id: ItemId(\"d\") }, 4: ItemSpecInfo { item_id: ItemId(\"e\") }, 5: ItemSpecInfo { item_id: ItemId(\"f\") }}, edge weights: {0: Contains, 1: Logic, 2: Logic, 3: Contains, 4: Logic, 5: Logic, 6: Data, 7: Data, 8: Data} }, cycle_state: DfsSpace { dfs: Dfs { stack: [], discovered: FixedBitSet { data: 0x10, capacity: 0, length: 0 } } } } \
             } \
         }",
         format!("{flow_spec_info:?}")

--- a/workspace_tests/src/mock_item.rs
+++ b/workspace_tests/src/mock_item.rs
@@ -416,7 +416,7 @@ where
     dest: W<'exec, MockDest>,
 }
 
-impl<'exec, Id> MockData<'exec, Id>
+impl<Id> MockData<'_, Id>
 where
     Id: Clone + Debug + Default + Send + Sync + 'static,
 {


### PR DESCRIPTION
Release build of `envman` now doesn't crash on the web interface.